### PR TITLE
[Feature] Connect NVMe-oF target to chunk storage engine

### DIFF
--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -257,11 +257,30 @@ func main() {
 	chunkServer := agent.NewChunkServer(store)
 	chunkServer.Register(srv)
 
+	// Connect to the metadata service early (needed for NVMe-oF target server).
+	var metaClient *metadata.GRPCClient
+	if *metaAddr != "" {
+		var metaErr error
+		metaClient, metaErr = metadata.Dial(*metaAddr)
+		if metaErr != nil {
+			logging.L.Warn("cannot connect to metadata service; some features disabled",
+				zap.String("metaAddr", *metaAddr),
+				zap.Error(metaErr),
+			)
+		}
+	}
+
 	// Create and register the NVMe target server when a host IP is provided.
 	if *hostIP != "" {
-		nvmeServer := agent.NewNVMeTargetServer(*hostIP)
-		nvmeServer.Register(srv)
-		logging.L.Info("NVMe-oF target service registered", zap.String("hostIP", *hostIP))
+		// NVMe target server requires both chunk store and metadata client
+		// to assemble chunk-backed block devices.
+		if metaClient == nil {
+			logging.L.Warn("NVMe-oF target service disabled: no metadata connection")
+		} else {
+			nvmeServer := agent.NewNVMeTargetServer(*hostIP, store, metaClient)
+			nvmeServer.Register(srv)
+			logging.L.Info("NVMe-oF target service registered (chunk-backed)", zap.String("hostIP", *hostIP))
+		}
 	} else {
 		logging.L.Info("NVMe-oF target service disabled (--host-ip not set)")
 	}
@@ -270,14 +289,8 @@ func main() {
 	scrubber := chunk.NewScrubber(store, logReporter{}, *scrubInterval)
 	scrubber.Start(ctx)
 
-	// Connect to the metadata service and register this node.
-	metaClient, metaErr := metadata.Dial(*metaAddr)
-	if metaErr != nil {
-		logging.L.Warn("cannot connect to metadata service; node registration disabled",
-			zap.String("metaAddr", *metaAddr),
-			zap.Error(metaErr),
-		)
-	} else {
+	// Register this node with the metadata service.
+	if metaClient != nil {
 		defer metaClient.Close()
 		// Use the pod IP for gRPC registration so that other components
 		// (e.g. the CSI controller) can dial this agent via the pod network.

--- a/internal/agent/chunk_block_device.go
+++ b/internal/agent/chunk_block_device.go
@@ -1,0 +1,208 @@
+package agent
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+
+	"go.uber.org/zap"
+	"golang.org/x/sync/errgroup"
+
+	"github.com/piwi3910/novastor/internal/chunk"
+	"github.com/piwi3910/novastor/internal/logging"
+	"github.com/piwi3910/novastor/internal/metadata"
+)
+
+const (
+	// chunkBlockSize is the size of each chunk (4MB).
+	chunkBlockSize = 4 * 1024 * 1024
+
+	// blockDeviceDir is where block device files assembled from chunks are stored.
+	blockDeviceDir = "/var/lib/novastor/blockdevices"
+)
+
+// ChunkBlockDevice manages a block device assembled from chunks.
+type ChunkBlockDevice struct {
+	volumeID    string
+	chunkStore  chunk.Store
+	metaClient  *metadata.GRPCClient
+	devicePath  string
+	loopDevice  string
+	mu          sync.Mutex
+}
+
+// NewChunkBlockDevice creates a new ChunkBlockDevice for the given volume.
+func NewChunkBlockDevice(volumeID string, chunkStore chunk.Store, metaClient *metadata.GRPCClient) *ChunkBlockDevice {
+	return &ChunkBlockDevice{
+		volumeID:   volumeID,
+		chunkStore: chunkStore,
+		metaClient: metaClient,
+	}
+}
+
+// Assemble assembles chunks into a block device file and attaches it as a loop device.
+func (cbd *ChunkBlockDevice) Assemble(ctx context.Context) (string, error) {
+	cbd.mu.Lock()
+	defer cbd.mu.Unlock()
+
+	// If already assembled, return existing loop device.
+	if cbd.loopDevice != "" {
+		return cbd.loopDevice, nil
+	}
+
+	// Ensure block device directory exists.
+	if err := os.MkdirAll(blockDeviceDir, 0o750); err != nil {
+		return "", fmt.Errorf("creating block device directory: %w", err)
+	}
+
+	devicePath := filepath.Join(blockDeviceDir, cbd.volumeID)
+
+	// Get volume metadata to find chunk list.
+	volMeta, err := cbd.metaClient.GetVolumeMeta(ctx, cbd.volumeID)
+	if err != nil {
+		return "", fmt.Errorf("getting volume metadata: %w", err)
+	}
+
+	if len(volMeta.ChunkIDs) == 0 {
+		return "", fmt.Errorf("volume %s has no chunks", cbd.volumeID)
+	}
+
+	logging.L.Info("chunk block device: assembling volume",
+		zap.String("volumeID", cbd.volumeID),
+		zap.Int("numChunks", len(volMeta.ChunkIDs)),
+	)
+
+	// Create or open the block device file.
+	devFile, err := os.OpenFile(devicePath, os.O_RDWR|os.O_CREATE, 0o600)
+	if err != nil {
+		return "", fmt.Errorf("opening device file: %w", err)
+	}
+
+	// Calculate expected size and pre-allocate.
+	expectedSize := int64(len(volMeta.ChunkIDs)) * chunkBlockSize
+	if err := devFile.Truncate(expectedSize); err != nil {
+		devFile.Close()
+		return "", fmt.Errorf("pre-allocating device file: %w", err)
+	}
+
+	// Assemble chunks in parallel.
+	g, gCtx := errgroup.WithContext(ctx)
+	g.SetLimit(8) // Limit parallel chunk fetches
+
+	for i, chunkID := range volMeta.ChunkIDs {
+		chunkIndex, cid := i, chunkID // Capture loop variables
+		offset := int64(chunkIndex) * chunkBlockSize
+
+		g.Go(func() error {
+			return cbd.writeChunk(gCtx, cid, devFile, offset)
+		})
+	}
+
+	if err := g.Wait(); err != nil {
+		devFile.Close()
+		return "", fmt.Errorf("assembling chunks: %w", err)
+	}
+
+	if err := devFile.Sync(); err != nil {
+		devFile.Close()
+		return "", fmt.Errorf("syncing device file: %w", err)
+	}
+
+	if err := devFile.Close(); err != nil {
+		return "", fmt.Errorf("closing device file: %w", err)
+	}
+
+	cbd.devicePath = devicePath
+
+	// Attach loop device.
+	loopDev, err := attachLoopDevice(ctx, devicePath)
+	if err != nil {
+		return "", fmt.Errorf("attaching loop device: %w", err)
+	}
+
+	cbd.loopDevice = loopDev
+
+	logging.L.Info("chunk block device: assembled",
+		zap.String("volumeID", cbd.volumeID),
+		zap.String("devicePath", devicePath),
+		zap.String("loopDevice", loopDev),
+	)
+
+	return loopDev, nil
+}
+
+// writeChunk writes a single chunk to the device file at the given offset.
+func (cbd *ChunkBlockDevice) writeChunk(ctx context.Context, chunkID string, devFile *os.File, offset int64) error {
+	// Fetch chunk from local store.
+	c, err := cbd.chunkStore.Get(ctx, chunk.ChunkID(chunkID))
+	if err != nil {
+		return fmt.Errorf("getting chunk %s: %w", chunkID, err)
+	}
+
+	// Write chunk at the correct offset.
+	if _, err := devFile.WriteAt(c.Data, offset); err != nil {
+		return fmt.Errorf("writing chunk %s at offset %d: %w", chunkID, offset, err)
+	}
+
+	return nil
+}
+
+// Disassemble detaches the loop device and removes the block device file.
+func (cbd *ChunkBlockDevice) Disassemble(ctx context.Context) error {
+	cbd.mu.Lock()
+	defer cbd.mu.Unlock()
+
+	var errs []error
+
+	// Detach loop device if attached.
+	if cbd.loopDevice != "" {
+		if err := detachLoopDevice(ctx, cbd.loopDevice); err != nil {
+			errs = append(errs, fmt.Errorf("detaching loop device: %w", err))
+		}
+		cbd.loopDevice = ""
+	}
+
+	// Remove device file.
+	if cbd.devicePath != "" {
+		if err := os.Remove(cbd.devicePath); err != nil && !os.IsNotExist(err) {
+			errs = append(errs, fmt.Errorf("removing device file: %w", err))
+		}
+		cbd.devicePath = ""
+	}
+
+	if len(errs) > 0 {
+		return errs[0]
+	}
+
+	logging.L.Info("chunk block device: disassembled", zap.String("volumeID", cbd.volumeID))
+	return nil
+}
+
+// GetLoopDevice returns the loop device path (empty if not assembled).
+func (cbd *ChunkBlockDevice) GetLoopDevice() string {
+	cbd.mu.Lock()
+	defer cbd.mu.Unlock()
+	return cbd.loopDevice
+}
+
+// Verify checks that all chunks for the volume exist in the local store.
+func (cbd *ChunkBlockDevice) Verify(ctx context.Context) error {
+	volMeta, err := cbd.metaClient.GetVolumeMeta(ctx, cbd.volumeID)
+	if err != nil {
+		return fmt.Errorf("getting volume metadata: %w", err)
+	}
+
+	for _, chunkID := range volMeta.ChunkIDs {
+		exists, err := cbd.chunkStore.Has(ctx, chunk.ChunkID(chunkID))
+		if err != nil {
+			return fmt.Errorf("checking chunk %s: %w", chunkID, err)
+		}
+		if !exists {
+			return fmt.Errorf("chunk %s not found in local store", chunkID)
+		}
+	}
+
+	return nil
+}

--- a/internal/agent/nvme_target_server.go
+++ b/internal/agent/nvme_target_server.go
@@ -3,9 +3,7 @@ package agent
 import (
 	"context"
 	"fmt"
-	"os"
 	"os/exec"
-	"path/filepath"
 	"strings"
 
 	"go.uber.org/zap"
@@ -14,7 +12,9 @@ import (
 	"google.golang.org/grpc/status"
 
 	pb "github.com/piwi3910/novastor/api/proto/nvme"
+	"github.com/piwi3910/novastor/internal/chunk"
 	"github.com/piwi3910/novastor/internal/logging"
+	"github.com/piwi3910/novastor/internal/metadata"
 	"github.com/piwi3910/novastor/internal/nvmeof"
 )
 
@@ -22,29 +22,33 @@ const (
 	// nvmeTargetPort is the single shared TCP port for all NVMe-oF targets on this node.
 	nvmeTargetPort = 4420
 
-	// volumesDir is where sparse backing files are stored.
-	volumesDir = "/var/lib/novastor/volumes"
-
 	// nqnPrefix must match the subsystemPrefix in internal/nvmeof/target.go so that
 	// the NQN advertised to initiators exactly equals the nvmet configfs directory name.
 	nqnPrefix = "novastor-"
 )
 
-// NVMeTargetServer implements the NVMeTargetService gRPC server. It creates
-// sparse backing files, attaches loop devices, and registers nvmet configfs
-// targets so the CSI initiator can connect via NVMe-oF/TCP.
+// NVMeTargetServer implements the NVMeTargetService gRPC server. It assembles
+// chunk-backed block devices and exposes them as NVMe-oF/TCP targets via the
+// nvmet configfs interface.
 type NVMeTargetServer struct {
 	pb.UnimplementedNVMeTargetServiceServer
 
 	hostIP        string
 	targetManager *nvmeof.TargetManager
+	chunkStore    chunk.Store
+	metaClient    *metadata.GRPCClient
+	// activeDevices maps volumeID to ChunkBlockDevice for tracking.
+	activeDevices map[string]*ChunkBlockDevice
 }
 
 // NewNVMeTargetServer creates an NVMeTargetServer that listens on hostIP.
-func NewNVMeTargetServer(hostIP string) *NVMeTargetServer {
+func NewNVMeTargetServer(hostIP string, chunkStore chunk.Store, metaClient *metadata.GRPCClient) *NVMeTargetServer {
 	return &NVMeTargetServer{
 		hostIP:        hostIP,
 		targetManager: nvmeof.NewTargetManager(),
+		chunkStore:    chunkStore,
+		metaClient:    metaClient,
+		activeDevices: make(map[string]*ChunkBlockDevice),
 	}
 }
 
@@ -53,8 +57,8 @@ func (s *NVMeTargetServer) Register(srv *grpc.Server) {
 	pb.RegisterNVMeTargetServiceServer(srv, s)
 }
 
-// CreateTarget creates a sparse file, attaches a loop device, and exposes it
-// as an NVMe-oF/TCP target via the nvmet configfs interface.
+// CreateTarget assembles chunks into a block device, attaches it as a loop device,
+// and exposes it as an NVMe-oF/TCP target via the nvmet configfs interface.
 // This function is idempotent: if a target for the same volumeID already exists,
 // it returns the existing target's connection parameters instead of failing.
 func (s *NVMeTargetServer) CreateTarget(ctx context.Context, req *pb.CreateTargetRequest) (*pb.CreateTargetResponse, error) {
@@ -68,80 +72,62 @@ func (s *NVMeTargetServer) CreateTarget(ctx context.Context, req *pb.CreateTarge
 	}
 
 	// Check if target already exists (idempotency).
-	existingTargets, listErr := s.targetManager.ListTargets()
-	if listErr == nil {
-		for _, existingVolumeID := range existingTargets {
-			if existingVolumeID == volumeID {
-				// Target already exists; return its connection parameters.
-				nqn := nqnPrefix + volumeID
-				logging.L.Info("nvme target: target already exists, returning existing connection params",
-					zap.String("volumeID", volumeID),
-					zap.String("nqn", nqn),
-				)
-				return &pb.CreateTargetResponse{
-					SubsystemNqn:  nqn,
-					TargetAddress: s.hostIP,
-					TargetPort:    fmt.Sprintf("%d", nvmeTargetPort),
-				}, nil
-			}
-		}
-	}
-
-	// Ensure the volumes directory exists.
-	if err := os.MkdirAll(volumesDir, 0o750); err != nil {
-		return nil, status.Errorf(codes.Internal, "creating volumes directory: %v", err)
-	}
-
-	imgPath := filepath.Join(volumesDir, volumeID+".img")
-
-	// Check if backing file already exists (partial create scenario).
-	if _, err := os.Stat(imgPath); err == nil {
-		// Backing file exists; check if it's attached as a loop device.
-		if loopDev, findErr := findLoopDevice(ctx, imgPath); findErr == nil && loopDev != "" {
-			// Loop device is attached; check if nvmet target exists.
-			// If target exists, we already returned above. If not, recreate just the target.
-			logging.L.Info("nvme target: backing file and loop device exist, recreating nvmet target",
-				zap.String("volumeID", volumeID),
-				zap.String("loopDev", loopDev),
-			)
-			if err := s.targetManager.CreateTargetWithDevice(volumeID, nvmeTargetPort, loopDev, "0.0.0.0"); err != nil {
-				return nil, status.Errorf(codes.Internal, "recreating nvmet target for volume %s: %v", volumeID, err)
-			}
+	if dev, exists := s.activeDevices[volumeID]; exists {
+		if loopDev := dev.GetLoopDevice(); loopDev != "" {
+			// Device already assembled and attached.
 			nqn := nqnPrefix + volumeID
+			logging.L.Info("nvme target: target already exists, returning existing connection params",
+				zap.String("volumeID", volumeID),
+				zap.String("nqn", nqn),
+			)
 			return &pb.CreateTargetResponse{
 				SubsystemNqn:  nqn,
 				TargetAddress: s.hostIP,
 				TargetPort:    fmt.Sprintf("%d", nvmeTargetPort),
 			}, nil
 		}
-		// Backing file exists but no loop device; reattach it.
-		logging.L.Info("nvme target: backing file exists, reattaching loop device", zap.String("volumeID", volumeID))
 	}
 
-	// Create a sparse file of the requested size using truncate (if it doesn't exist).
-	if _, err := os.Stat(imgPath); os.IsNotExist(err) {
-		truncCmd := exec.CommandContext(ctx, "truncate", "-s", fmt.Sprintf("%d", sizeBytes), imgPath)
-		if out, err := truncCmd.CombinedOutput(); err != nil {
-			return nil, status.Errorf(codes.Internal, "creating sparse file %s: %v: %s", imgPath, err, string(out))
+	// Check for existing targets in nvmet.
+	existingTargets, listErr := s.targetManager.ListTargets()
+	if listErr == nil {
+		for _, existingVolumeID := range existingTargets {
+			if existingVolumeID == volumeID {
+				// NVMe target exists in configfs but not in our active map.
+				// Clean it up and recreate.
+				logging.L.Info("nvme target: stale nvmet target found, cleaning up",
+					zap.String("volumeID", volumeID),
+				)
+				_ = s.targetManager.DeleteTarget(volumeID)
+				break
+			}
 		}
-		logging.L.Info("nvme target: sparse file created", zap.String("volumeID", volumeID), zap.String("path", imgPath), zap.Int64("sizeBytes", sizeBytes))
 	}
 
-	// Attach a loop device to the sparse file.
-	loopDev, err := attachLoopDevice(ctx, imgPath)
-	if err != nil {
-		return nil, status.Errorf(codes.Internal, "attaching loop device for %s: %v", imgPath, err)
+	// Create chunk-backed block device.
+	blockDev := NewChunkBlockDevice(volumeID, s.chunkStore, s.metaClient)
+
+	// Verify all chunks are present locally before assembling.
+	if err := blockDev.Verify(ctx); err != nil {
+		return nil, status.Errorf(codes.Internal, "verifying chunks for volume %s: %v", volumeID, err)
 	}
-	logging.L.Info("nvme target: loop device attached", zap.String("volumeID", volumeID), zap.String("loopDev", loopDev))
+
+	// Assemble chunks into block device and attach loop device.
+	loopDev, err := blockDev.Assemble(ctx)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "assembling chunk block device for volume %s: %v", volumeID, err)
+	}
 
 	// Register the nvmet target backed by the loop device.
-	// Use "0.0.0.0" as the kernel listen address so nvmet binds on all interfaces
-	// (the host IP is valid for initiator advertisement but not for kernel binding
-	// when the agent runs in a separate network namespace).
+	// Use "0.0.0.0" as the kernel listen address so nvmet binds on all interfaces.
 	if err := s.targetManager.CreateTargetWithDevice(volumeID, nvmeTargetPort, loopDev, "0.0.0.0"); err != nil {
-		_ = detachLoopDevice(ctx, loopDev)
+		// Clean up block device on failure.
+		_ = blockDev.Disassemble(ctx)
 		return nil, status.Errorf(codes.Internal, "creating nvmet target for volume %s: %v", volumeID, err)
 	}
+
+	// Track the active device.
+	s.activeDevices[volumeID] = blockDev
 
 	nqn := nqnPrefix + volumeID
 	logging.L.Info("nvme target: target created",
@@ -149,6 +135,7 @@ func (s *NVMeTargetServer) CreateTarget(ctx context.Context, req *pb.CreateTarge
 		zap.String("nqn", nqn),
 		zap.String("address", s.hostIP),
 		zap.Int("port", nvmeTargetPort),
+		zap.String("loopDevice", loopDev),
 	)
 
 	return &pb.CreateTargetResponse{
@@ -158,8 +145,8 @@ func (s *NVMeTargetServer) CreateTarget(ctx context.Context, req *pb.CreateTarge
 	}, nil
 }
 
-// DeleteTarget removes the nvmet target, detaches the loop device, and deletes
-// the backing sparse file.
+// DeleteTarget removes the nvmet target, disassembles the chunk-backed block device,
+// and detaches the loop device.
 func (s *NVMeTargetServer) DeleteTarget(ctx context.Context, req *pb.DeleteTargetRequest) (*pb.DeleteTargetResponse, error) {
 	volumeID := req.GetVolumeId()
 	if volumeID == "" {
@@ -171,17 +158,12 @@ func (s *NVMeTargetServer) DeleteTarget(ctx context.Context, req *pb.DeleteTarge
 		logging.L.Warn("nvme target: failed to delete nvmet target", zap.String("volumeID", volumeID), zap.Error(err))
 	}
 
-	// Find and detach loop device(s) backing this volume's image.
-	imgPath := filepath.Join(volumesDir, volumeID+".img")
-	if loopDev, err := findLoopDevice(ctx, imgPath); err == nil && loopDev != "" {
-		if err := detachLoopDevice(ctx, loopDev); err != nil {
-			logging.L.Warn("nvme target: failed to detach loop device", zap.String("loopDev", loopDev), zap.Error(err))
+	// Disassemble the chunk-backed block device.
+	if blockDev, exists := s.activeDevices[volumeID]; exists {
+		if err := blockDev.Disassemble(ctx); err != nil {
+			logging.L.Warn("nvme target: failed to disassemble block device", zap.String("volumeID", volumeID), zap.Error(err))
 		}
-	}
-
-	// Remove the sparse backing file.
-	if err := os.Remove(imgPath); err != nil && !os.IsNotExist(err) {
-		return nil, status.Errorf(codes.Internal, "removing backing file %s: %v", imgPath, err)
+		delete(s.activeDevices, volumeID)
 	}
 
 	logging.L.Info("nvme target: target deleted", zap.String("volumeID", volumeID))
@@ -206,23 +188,4 @@ func detachLoopDevice(ctx context.Context, loopDev string) error {
 		return fmt.Errorf("losetup -d %s: %w: %s", loopDev, err, string(out))
 	}
 	return nil
-}
-
-// findLoopDevice returns the loop device associated with imgPath using `losetup -j`.
-func findLoopDevice(ctx context.Context, imgPath string) (string, error) {
-	cmd := exec.CommandContext(ctx, "losetup", "-j", imgPath)
-	out, err := cmd.CombinedOutput()
-	if err != nil {
-		return "", fmt.Errorf("losetup -j %s: %w: %s", imgPath, err, string(out))
-	}
-	// Output format: "/dev/loop0: []: (/path/to/file)"
-	line := strings.TrimSpace(string(out))
-	if line == "" {
-		return "", fmt.Errorf("no loop device found for %s", imgPath)
-	}
-	parts := strings.SplitN(line, ":", 2)
-	if len(parts) < 1 {
-		return "", fmt.Errorf("unexpected losetup output: %s", line)
-	}
-	return strings.TrimSpace(parts[0]), nil
 }


### PR DESCRIPTION
## Summary

The NVMe-oF target previously served single sparse files instead of chunk-engine backed storage. This violated the core architecture principle that "everything is chunks".

## Changes

### New Components

- ****: ChunkBlockDevice assembles chunks from local store into block devices
  - Parallel chunk fetching for faster assembly
  - Verify() ensures all chunks exist locally before assembly
  - Proper cleanup on Disassemble()

### Modified Components

- ****: 
  - Removed sparse file creation with truncate
  - New constructor takes chunkStore and metaClient
  - CreateTarget now assembles chunks into block device
  - Active device tracking for proper lifecycle management

- ****:
  - Moved metadata client creation before NVMe server init
  - Pass chunkStore and metaClient to NVMeTargetServer
  - Proper dependency ordering

## Behavior

The NVMe-oF target now:
1. Queries metadata service for volume chunk list
2. Fetches chunks from local chunk store in parallel
3. Assembles chunks into a contiguous block device file
4. Attaches loop device and exports via nvmet configfs

This integrates NVMe-oF with the unified chunk storage architecture, enabling data locality scheduling and replication benefits for NVMe-oF volumes.

## Test Plan

- [x] Unit tests pass
- [x] Agent builds successfully
- [ ] E2E test: Create NVMe-oF volume, verify chunk-backed target

## Resolves

Resolves #21