### PR TITLE
[Fix] Implement CSI ControllerPublishVolume and ControllerUnpublishVolume

### DIFF
--- a/internal/csi/controller.go
+++ b/internal/csi/controller.go
@@ -290,14 +290,88 @@ func (cs *ControllerServer) ListVolumes(ctx context.Context, req *csi.ListVolume
 	}, nil
 }
 
-// ControllerPublishVolume is handled at the node level.
-func (cs *ControllerServer) ControllerPublishVolume(_ context.Context, _ *csi.ControllerPublishVolumeRequest) (*csi.ControllerPublishVolumeResponse, error) {
-	return nil, status.Error(codes.Unimplemented, "ControllerPublishVolume is not supported")
+// ControllerPublishVolume publishes a volume to a node.
+// For NovaStor, this is a lightweight validation that the volume exists.
+// The actual volume attachment (NVMe-oF connection or NFS mount) happens
+// at the node level via NodeStageVolume/NodePublishVolume.
+// This implementation is idempotent: republishing an already published
+// volume succeeds with the same publish context.
+func (cs *ControllerServer) ControllerPublishVolume(ctx context.Context, req *csi.ControllerPublishVolumeRequest) (*csi.ControllerPublishVolumeResponse, error) {
+	start := time.Now()
+	defer func() {
+		metrics.VolumePublishDuration.Observe(time.Since(start).Seconds())
+	}()
+
+	volumeID := req.GetVolumeId()
+	if volumeID == "" {
+		return nil, status.Error(codes.InvalidArgument, "volume ID is required")
+	}
+
+	nodeID := req.GetNodeId()
+	if nodeID == "" {
+		return nil, status.Error(codes.InvalidArgument, "node ID is required")
+	}
+
+	// Verify the volume exists.
+	vm, err := cs.meta.GetVolumeMeta(ctx, volumeID)
+	if err != nil {
+		return nil, status.Errorf(codes.NotFound, "volume %s not found", volumeID)
+	}
+
+	// Build publish context with information the node will need.
+	publishContext := map[string]string{
+		"volumeId": volumeID,
+	}
+
+	// Determine access type from volume metadata.
+	// For RWX (NFS) volumes, the CreateVolume sets volume context with accessMode="RWX".
+	// For block volumes with NVMe-oF targets, SubsystemNQN will be populated.
+	if vm.SubsystemNQN != "" {
+		// RWO block volume with NVMe-oF target.
+		publishContext["accessType"] = "nvmeof"
+		publishContext["subsystemNQN"] = vm.SubsystemNQN
+		publishContext["targetAddress"] = vm.TargetAddress
+		publishContext["targetPort"] = vm.TargetPort
+		publishContext["targetNodeID"] = vm.TargetNodeID
+	} else {
+		// Basic block volume (without NVMe-oF) or NFS volume.
+		// The node will determine the actual access method based on
+		// volume capabilities passed to NodeStageVolume/NodePublishVolume.
+		publishContext["accessType"] = "block"
+	}
+
+	return &csi.ControllerPublishVolumeResponse{
+		PublishContext: publishContext,
+	}, nil
 }
 
-// ControllerUnpublishVolume is handled at the node level.
-func (cs *ControllerServer) ControllerUnpublishVolume(_ context.Context, _ *csi.ControllerUnpublishVolumeRequest) (*csi.ControllerUnpublishVolumeResponse, error) {
-	return nil, status.Error(codes.Unimplemented, "ControllerUnpublishVolume is not supported")
+// ControllerUnpublishVolume unpublishes a volume from a node.
+// For NovaStor, this is a no-op at the controller level since the
+// actual detachment happens at the node level. This implementation
+// is idempotent: unpublishing a non-existent or already unpublished
+// volume succeeds.
+func (cs *ControllerServer) ControllerUnpublishVolume(ctx context.Context, req *csi.ControllerUnpublishVolumeRequest) (*csi.ControllerUnpublishVolumeResponse, error) {
+	start := time.Now()
+	defer func() {
+		metrics.VolumeUnpublishDuration.Observe(time.Since(start).Seconds())
+	}()
+
+	volumeID := req.GetVolumeId()
+	if volumeID == "" {
+		return nil, status.Error(codes.InvalidArgument, "volume ID is required")
+	}
+
+	// NodeID is optional per CSI spec for unpublish (can be empty for forced cleanup).
+	// We don't enforce node-specific tracking at the controller level.
+
+	// Verify the volume exists. If not, succeed idempotently per CSI spec.
+	if _, err := cs.meta.GetVolumeMeta(ctx, volumeID); err != nil {
+		// Volume doesn't exist or was already deleted - succeed idempotently.
+		return &csi.ControllerUnpublishVolumeResponse{}, nil
+	}
+
+	// No controller-side state to clean up. The node handles the actual detachment.
+	return &csi.ControllerUnpublishVolumeResponse{}, nil
 }
 
 // GetCapacity is not supported.
@@ -311,6 +385,7 @@ func (cs *ControllerServer) ControllerGetCapabilities(_ context.Context, _ *csi.
 		csi.ControllerServiceCapability_RPC_CREATE_DELETE_VOLUME,
 		csi.ControllerServiceCapability_RPC_CREATE_DELETE_SNAPSHOT,
 		csi.ControllerServiceCapability_RPC_EXPAND_VOLUME,
+		csi.ControllerServiceCapability_RPC_PUBLISH_UNPUBLISH_VOLUME,
 	}
 
 	var capabilities []*csi.ControllerServiceCapability

--- a/internal/csi/controller_test.go
+++ b/internal/csi/controller_test.go
@@ -444,21 +444,242 @@ func TestListVolumes_InvalidToken(t *testing.T) {
 	}
 }
 
-// --- Unimplemented RPCs ---
+// --- ControllerPublishVolume tests ---
 
-func TestControllerPublishVolumeUnimplemented(t *testing.T) {
+func TestControllerPublishVolume_Success(t *testing.T) {
 	cs, _ := setupController()
-	_, err := cs.ControllerPublishVolume(context.Background(), &csi.ControllerPublishVolumeRequest{})
-	if st, ok := status.FromError(err); !ok || st.Code() != codes.Unimplemented {
-		t.Errorf("expected Unimplemented, got %v", err)
+
+	// Create a volume first.
+	createResp, err := cs.CreateVolume(context.Background(), &csi.CreateVolumeRequest{
+		Name:          "publish-vol",
+		CapacityRange: &csi.CapacityRange{RequiredBytes: 4 * 1024 * 1024},
+	})
+	if err != nil {
+		t.Fatalf("CreateVolume failed: %v", err)
+	}
+
+	volumeID := createResp.GetVolume().GetVolumeId()
+
+	// Publish the volume to a node.
+	resp, err := cs.ControllerPublishVolume(context.Background(), &csi.ControllerPublishVolumeRequest{
+		VolumeId: volumeID,
+		NodeId:   "node-1",
+	})
+	if err != nil {
+		t.Fatalf("ControllerPublishVolume failed: %v", err)
+	}
+
+	// Check publish context contains required fields.
+	pubCtx := resp.GetPublishContext()
+	if pubCtx["volumeId"] != volumeID {
+		t.Errorf("expected volumeId %s in publish context, got %q", volumeID, pubCtx["volumeId"])
+	}
+	if pubCtx["accessType"] != "block" {
+		t.Errorf("expected accessType block, got %q", pubCtx["accessType"])
 	}
 }
 
-func TestControllerUnpublishVolumeUnimplemented(t *testing.T) {
+func TestControllerPublishVolume_RWX(t *testing.T) {
+	cs, _ := setupController()
+
+	// Create an RWX volume.
+	createResp, err := cs.CreateVolume(context.Background(), &csi.CreateVolumeRequest{
+		Name:          "publish-rwx",
+		CapacityRange: &csi.CapacityRange{RequiredBytes: 4 * 1024 * 1024},
+		VolumeCapabilities: []*csi.VolumeCapability{
+			{
+				AccessMode: &csi.VolumeCapability_AccessMode{
+					Mode: csi.VolumeCapability_AccessMode_MULTI_NODE_MULTI_WRITER,
+				},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("CreateVolume failed: %v", err)
+	}
+
+	volumeID := createResp.GetVolume().GetVolumeId()
+
+	// Publish the RWX volume.
+	// Note: ControllerPublishVolume doesn't need VolumeCapabilities in the request
+	// since the access type is determined from the volume metadata.
+	resp, err := cs.ControllerPublishVolume(context.Background(), &csi.ControllerPublishVolumeRequest{
+		VolumeId: volumeID,
+		NodeId:   "node-1",
+	})
+	if err != nil {
+		t.Fatalf("ControllerPublishVolume RWX failed: %v", err)
+	}
+
+	// RWX volumes without NVMe-oF targets get "block" accessType by default
+	// since the node will handle NFS mounting based on volume context.
+	pubCtx := resp.GetPublishContext()
+	if pubCtx["accessType"] != "block" {
+		t.Errorf("expected accessType block, got %q", pubCtx["accessType"])
+	}
+	if pubCtx["volumeId"] != volumeID {
+		t.Errorf("expected volumeId %s, got %q", volumeID, pubCtx["volumeId"])
+	}
+}
+
+func TestControllerPublishVolume_NoVolumeID(t *testing.T) {
+	cs, _ := setupController()
+	_, err := cs.ControllerPublishVolume(context.Background(), &csi.ControllerPublishVolumeRequest{
+		NodeId: "node-1",
+	})
+	if err == nil {
+		t.Fatal("expected error for missing volume ID")
+	}
+	if st, ok := status.FromError(err); !ok || st.Code() != codes.InvalidArgument {
+		t.Errorf("expected InvalidArgument, got %v", err)
+	}
+}
+
+func TestControllerPublishVolume_NoNodeID(t *testing.T) {
+	cs, _ := setupController()
+	_, err := cs.ControllerPublishVolume(context.Background(), &csi.ControllerPublishVolumeRequest{
+		VolumeId: "some-volume",
+	})
+	if err == nil {
+		t.Fatal("expected error for missing node ID")
+	}
+	if st, ok := status.FromError(err); !ok || st.Code() != codes.InvalidArgument {
+		t.Errorf("expected InvalidArgument, got %v", err)
+	}
+}
+
+func TestControllerPublishVolume_NotFound(t *testing.T) {
+	cs, _ := setupController()
+	_, err := cs.ControllerPublishVolume(context.Background(), &csi.ControllerPublishVolumeRequest{
+		VolumeId: "nonexistent",
+		NodeId:   "node-1",
+	})
+	if err == nil {
+		t.Fatal("expected error for non-existent volume")
+	}
+	if st, ok := status.FromError(err); !ok || st.Code() != codes.NotFound {
+		t.Errorf("expected NotFound, got %v", err)
+	}
+}
+
+func TestControllerPublishVolume_Idempotent(t *testing.T) {
+	cs, _ := setupController()
+
+	// Create a volume.
+	createResp, err := cs.CreateVolume(context.Background(), &csi.CreateVolumeRequest{
+		Name:          "idempotent-vol",
+		CapacityRange: &csi.CapacityRange{RequiredBytes: 4 * 1024 * 1024},
+	})
+	if err != nil {
+		t.Fatalf("CreateVolume failed: %v", err)
+	}
+
+	volumeID := createResp.GetVolume().GetVolumeId()
+
+	// Publish twice - both should succeed.
+	_, err = cs.ControllerPublishVolume(context.Background(), &csi.ControllerPublishVolumeRequest{
+		VolumeId: volumeID,
+		NodeId:   "node-1",
+	})
+	if err != nil {
+		t.Fatalf("first publish failed: %v", err)
+	}
+
+	_, err = cs.ControllerPublishVolume(context.Background(), &csi.ControllerPublishVolumeRequest{
+		VolumeId: volumeID,
+		NodeId:   "node-1",
+	})
+	if err != nil {
+		t.Fatalf("second publish failed: %v", err)
+	}
+}
+
+// --- ControllerUnpublishVolume tests ---
+
+func TestControllerUnpublishVolume_Success(t *testing.T) {
+	cs, _ := setupController()
+
+	// Create a volume first.
+	createResp, err := cs.CreateVolume(context.Background(), &csi.CreateVolumeRequest{
+		Name:          "unpublish-vol",
+		CapacityRange: &csi.CapacityRange{RequiredBytes: 4 * 1024 * 1024},
+	})
+	if err != nil {
+		t.Fatalf("CreateVolume failed: %v", err)
+	}
+
+	volumeID := createResp.GetVolume().GetVolumeId()
+
+	// Publish first.
+	_, err = cs.ControllerPublishVolume(context.Background(), &csi.ControllerPublishVolumeRequest{
+		VolumeId: volumeID,
+		NodeId:   "node-1",
+	})
+	if err != nil {
+		t.Fatalf("ControllerPublishVolume failed: %v", err)
+	}
+
+	// Unpublish should succeed.
+	_, err = cs.ControllerUnpublishVolume(context.Background(), &csi.ControllerUnpublishVolumeRequest{
+		VolumeId: volumeID,
+		NodeId:   "node-1",
+	})
+	if err != nil {
+		t.Fatalf("ControllerUnpublishVolume failed: %v", err)
+	}
+}
+
+func TestControllerUnpublishVolume_NoVolumeID(t *testing.T) {
 	cs, _ := setupController()
 	_, err := cs.ControllerUnpublishVolume(context.Background(), &csi.ControllerUnpublishVolumeRequest{})
-	if st, ok := status.FromError(err); !ok || st.Code() != codes.Unimplemented {
-		t.Errorf("expected Unimplemented, got %v", err)
+	if err == nil {
+		t.Fatal("expected error for missing volume ID")
+	}
+	if st, ok := status.FromError(err); !ok || st.Code() != codes.InvalidArgument {
+		t.Errorf("expected InvalidArgument, got %v", err)
+	}
+}
+
+func TestControllerUnpublishVolume_Idempotent(t *testing.T) {
+	cs, _ := setupController()
+
+	// Create a volume.
+	createResp, err := cs.CreateVolume(context.Background(), &csi.CreateVolumeRequest{
+		Name:          "unpublish-idempotent",
+		CapacityRange: &csi.CapacityRange{RequiredBytes: 4 * 1024 * 1024},
+	})
+	if err != nil {
+		t.Fatalf("CreateVolume failed: %v", err)
+	}
+
+	volumeID := createResp.GetVolume().GetVolumeId()
+
+	// Unpublish multiple times - all should succeed.
+	_, err = cs.ControllerUnpublishVolume(context.Background(), &csi.ControllerUnpublishVolumeRequest{
+		VolumeId: volumeID,
+		NodeId:   "node-1",
+	})
+	if err != nil {
+		t.Fatalf("first unpublish failed: %v", err)
+	}
+
+	_, err = cs.ControllerUnpublishVolume(context.Background(), &csi.ControllerUnpublishVolumeRequest{
+		VolumeId: volumeID,
+		NodeId:   "node-1",
+	})
+	if err != nil {
+		t.Fatalf("second unpublish failed: %v", err)
+	}
+}
+
+func TestControllerUnpublishVolume_NonexistentVolume(t *testing.T) {
+	cs, _ := setupController()
+	// Unpublishing a non-existent volume should succeed idempotently.
+	_, err := cs.ControllerUnpublishVolume(context.Background(), &csi.ControllerUnpublishVolumeRequest{
+		VolumeId: "does-not-exist",
+	})
+	if err != nil {
+		t.Fatalf("expected idempotent unpublish to succeed, got: %v", err)
 	}
 }
 
@@ -480,9 +701,10 @@ func TestControllerGetCapabilities(t *testing.T) {
 	}
 
 	expected := map[csi.ControllerServiceCapability_RPC_Type]bool{
-		csi.ControllerServiceCapability_RPC_CREATE_DELETE_VOLUME:   false,
-		csi.ControllerServiceCapability_RPC_CREATE_DELETE_SNAPSHOT: false,
-		csi.ControllerServiceCapability_RPC_EXPAND_VOLUME:          false,
+		csi.ControllerServiceCapability_RPC_CREATE_DELETE_VOLUME:     false,
+		csi.ControllerServiceCapability_RPC_CREATE_DELETE_SNAPSHOT:   false,
+		csi.ControllerServiceCapability_RPC_EXPAND_VOLUME:            false,
+		csi.ControllerServiceCapability_RPC_PUBLISH_UNPUBLISH_VOLUME: false,
 	}
 
 	for _, cap := range resp.GetCapabilities() {

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -158,6 +158,24 @@ var (
 		Buckets:   prometheus.DefBuckets,
 	})
 
+	// VolumePublishDuration tracks the time to publish a volume to a node.
+	VolumePublishDuration = prometheus.NewHistogram(prometheus.HistogramOpts{
+		Namespace: "novastor",
+		Subsystem: "csi",
+		Name:      "volume_publish_duration_seconds",
+		Help:      "Time to publish a volume to a node",
+		Buckets:   prometheus.DefBuckets,
+	})
+
+	// VolumeUnpublishDuration tracks the time to unpublish a volume from a node.
+	VolumeUnpublishDuration = prometheus.NewHistogram(prometheus.HistogramOpts{
+		Namespace: "novastor",
+		Subsystem: "csi",
+		Name:      "volume_unpublish_duration_seconds",
+		Help:      "Time to unpublish a volume from a node",
+		Buckets:   prometheus.DefBuckets,
+	})
+
 	// --------------- S3 gateway metrics ---------------
 
 	// S3RequestsTotal counts S3 requests by operation type.
@@ -248,6 +266,8 @@ func Register() {
 	prometheus.MustRegister(VolumeCount)
 	prometheus.MustRegister(VolumeProvisionDuration)
 	prometheus.MustRegister(VolumeDeleteDuration)
+	prometheus.MustRegister(VolumePublishDuration)
+	prometheus.MustRegister(VolumeUnpublishDuration)
 
 	// S3 gateway metrics
 	prometheus.MustRegister(S3RequestsTotal)


### PR DESCRIPTION
## Summary

Implements the CSI ControllerPublishVolume and ControllerUnpublishVolume RPCs, which were previously returning Unimplemented. These operations are required for full CSI compliance and are used by Kubernetes to manage volume attachment to nodes.

## Changes

- **ControllerPublishVolume**: Validates volume exists and returns publish context with volume information (volumeId, accessType, NVMe-oF target details)
- **ControllerUnpublishVolume**: Idempotent no-op at controller level (actual detachment happens at node level)
- **ControllerGetCapabilities**: Added PUBLISH_UNPUBLISH_VOLUME capability
- **Metrics**: Added VolumePublishDuration and VolumeUnpublishDuration histograms
- **Tests**: Comprehensive test coverage for both operations

## Test Plan

- [x] Unit tests for publish/unpublish operations
- [x] Idempotency tests
- [x] Error handling tests (missing volume ID, missing node ID, volume not found)
- [x] All existing tests still pass

## Resolves

Resolves #19