### PR TITLE
[Fix] Write placement maps during CreateVolume for recovery manager

### DIFF
--- a/cmd/csi/main.go
+++ b/cmd/csi/main.go
@@ -96,6 +96,14 @@ func (a *snapshotStoreAdapter) ListVolumesMeta(ctx context.Context) ([]*metadata
 	return a.client.ListVolumesMeta(ctx)
 }
 
+func (a *snapshotStoreAdapter) PutPlacementMap(ctx context.Context, pm *metadata.PlacementMap) error {
+	return a.client.PutPlacementMap(ctx, pm)
+}
+
+func (a *snapshotStoreAdapter) DeletePlacementMap(ctx context.Context, chunkID string) error {
+	return a.client.DeletePlacementMap(ctx, chunkID)
+}
+
 func (a *snapshotStoreAdapter) PutSnapshotMeta(ctx context.Context, meta *novcsi.SnapshotMeta) error {
 	return a.client.PutSnapshot(ctx, &metadata.SnapshotMeta{
 		SnapshotID:     meta.SnapshotID,

--- a/internal/csi/controller.go
+++ b/internal/csi/controller.go
@@ -30,6 +30,9 @@ type MetadataStore interface {
 	GetVolumeMeta(ctx context.Context, volumeID string) (*metadata.VolumeMeta, error)
 	DeleteVolumeMeta(ctx context.Context, volumeID string) error
 	ListVolumesMeta(ctx context.Context) ([]*metadata.VolumeMeta, error)
+	// Placement map methods for recovery management.
+	PutPlacementMap(ctx context.Context, pm *metadata.PlacementMap) error
+	DeletePlacementMap(ctx context.Context, chunkID string) error
 }
 
 // PlacementEngine selects storage nodes for new chunks.
@@ -118,6 +121,22 @@ func (cs *ControllerServer) CreateVolume(ctx context.Context, req *csi.CreateVol
 		ChunkIDs:  chunkIDs,
 	}
 
+	// Write placement maps for each chunk. This is critical for recovery:
+	// if a node fails, the recovery manager uses these maps to know which
+	// chunks were on that node and need re-replication.
+	// Each chunk is placed on the node at the same index in nodeIDs.
+	for i, chunkID := range chunkIDs {
+		if i < len(nodeIDs) {
+			pm := &metadata.PlacementMap{
+				ChunkID: chunkID,
+				Nodes:   []string{nodeIDs[i]},
+			}
+			if err := cs.meta.PutPlacementMap(ctx, pm); err != nil {
+				return nil, status.Errorf(codes.Internal, "writing placement map for chunk %s: %v", chunkID, err)
+			}
+		}
+	}
+
 	// Set volume context for RWX (NFS-backed) volumes.
 	volContext := map[string]string{}
 	if hasRWXCapability(req.GetVolumeCapabilities()) {
@@ -190,6 +209,19 @@ func (cs *ControllerServer) DeleteVolume(ctx context.Context, req *csi.DeleteVol
 			logging.L.Warn("failed to delete NVMe-oF target (proceeding with metadata cleanup)",
 				zap.String("volumeID", volumeID),
 				zap.String("targetNodeID", vm.TargetNodeID),
+				zap.Error(deleteErr))
+		}
+	}
+
+	// Clean up placement maps for all chunks in this volume (best-effort).
+	for _, chunkID := range vm.ChunkIDs {
+		if deleteErr := cs.meta.DeletePlacementMap(ctx, chunkID); deleteErr != nil {
+			// Log but don't fail the delete operation if placement map cleanup fails.
+			// The volume metadata takes precedence; orphaned placement maps will be
+			// cleaned up by the garbage collector.
+			logging.L.Warn("failed to delete placement map (proceeding with metadata cleanup)",
+				zap.String("volumeID", volumeID),
+				zap.String("chunkID", chunkID),
 				zap.Error(deleteErr))
 		}
 	}

--- a/internal/csi/controller_test.go
+++ b/internal/csi/controller_test.go
@@ -58,6 +58,16 @@ func (m *mockMetadataStore) ListVolumesMeta(_ context.Context) ([]*metadata.Volu
 	return result, nil
 }
 
+func (m *mockMetadataStore) PutPlacementMap(_ context.Context, pm *metadata.PlacementMap) error {
+	// No-op for tests: placement maps are not tested in the mock.
+	return nil
+}
+
+func (m *mockMetadataStore) DeletePlacementMap(_ context.Context, chunkID string) error {
+	// No-op for tests: placement maps are not tested in the mock.
+	return nil
+}
+
 // --- mock placement engine ---
 
 type mockPlacer struct {

--- a/internal/csi/snapshot_test.go
+++ b/internal/csi/snapshot_test.go
@@ -62,6 +62,16 @@ func (m *mockSnapshotStore) ListVolumesMeta(_ context.Context) ([]*metadata.Volu
 	return result, nil
 }
 
+func (m *mockSnapshotStore) PutPlacementMap(_ context.Context, pm *metadata.PlacementMap) error {
+	// No-op for tests.
+	return nil
+}
+
+func (m *mockSnapshotStore) DeletePlacementMap(_ context.Context, chunkID string) error {
+	// No-op for tests.
+	return nil
+}
+
 func (m *mockSnapshotStore) PutSnapshotMeta(_ context.Context, meta *SnapshotMeta) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()

--- a/internal/metadata/grpc_client.go
+++ b/internal/metadata/grpc_client.go
@@ -162,6 +162,14 @@ func (c *GRPCClient) ListPlacementMaps(ctx context.Context) ([]*PlacementMap, er
 	return pms, nil
 }
 
+// DeletePlacementMap removes a placement map entry by chunk ID.
+func (c *GRPCClient) DeletePlacementMap(ctx context.Context, chunkID string) error {
+	_, err := c.exec(ctx, "DeletePlacementMap", struct {
+		ChunkID string `json:"chunkID"`
+	}{ChunkID: chunkID})
+	return err
+}
+
 // ---- Object operations ----
 
 // PutObjectMeta stores object metadata via the remote metadata service.

--- a/internal/metadata/grpc_server.go
+++ b/internal/metadata/grpc_server.go
@@ -51,6 +51,8 @@ func (s *GRPCServer) Execute(ctx context.Context, req *pb.MetadataRequest) (*pb.
 		return s.getPlacementMap(ctx, req.Payload)
 	case "ListPlacementMaps":
 		return s.listPlacementMaps(ctx)
+	case "DeletePlacementMap":
+		return s.deletePlacementMap(ctx, req.Payload)
 
 	// ---- Object operations ----
 	case "PutObjectMeta":
@@ -223,6 +225,19 @@ func (s *GRPCServer) listPlacementMaps(ctx context.Context) (*pb.MetadataRespons
 		return errResp(err), nil
 	}
 	return okResp(pms)
+}
+
+func (s *GRPCServer) deletePlacementMap(ctx context.Context, payload []byte) (*pb.MetadataResponse, error) {
+	var args struct {
+		ChunkID string `json:"chunkID"`
+	}
+	if err := json.Unmarshal(payload, &args); err != nil {
+		return errResp(fmt.Errorf("unmarshal args: %w", err)), nil
+	}
+	if err := s.store.DeletePlacementMap(ctx, args.ChunkID); err != nil {
+		return errResp(err), nil
+	}
+	return &pb.MetadataResponse{}, nil
 }
 
 // ---- Object operations ----

--- a/internal/metadata/store.go
+++ b/internal/metadata/store.go
@@ -340,6 +340,11 @@ func (s *RaftStore) ListPlacementMaps(_ context.Context) ([]*PlacementMap, error
 	return result, nil
 }
 
+// DeletePlacementMap removes a placement map entry.
+func (s *RaftStore) DeletePlacementMap(_ context.Context, chunkID string) error {
+	return s.apply(&fsmOp{Op: opDelete, Bucket: bucketPlacements, Key: chunkID})
+}
+
 // splitAndTrim splits a comma-separated list of addresses and trims whitespace.
 func splitAndTrim(s string) []string {
 	parts := strings.Split(s, ",")


### PR DESCRIPTION
## Summary

Fixes critical bug where CSI CreateVolume never writes placement maps to the metadata store, causing the recovery manager to have no data to work with for automatic chunk re-replication after node failures.

## Problem

The `RecoveryManager` in `internal/operator/recovery.go` detects node failures and triggers chunk re-replication by calling `placement.ChunksOnNode()`, which queries placement maps from the metadata service. However, `CreateVolume` never called `PutPlacementMap()`, so placement maps were empty and recovery was non-functional.

## Changes

- **CSI CreateVolume**: Writes a `PlacementMap` for each chunk to metadata store
- **CSI DeleteVolume**: Cleans up placement maps for all chunks
- **RaftStore**: Added `DeletePlacementMap` method
- **gRPC client/server**: Added `DeletePlacementMap` RPC support
- **MetadataStore interface**: Added `PutPlacementMap` and `DeletePlacementMap` methods
- **Test mocks**: Updated to include placement map methods

## Impact

- Recovery manager can now identify which chunks were on failed nodes
- Automatic re-replication of chunks to healthy nodes is functional
- Prevents permanent data loss after node failures

## Test Plan

- [x] All existing tests pass
- [x] Mock stores implement new interface methods
- [x] CSI binary builds successfully

## Resolves

Resolves #20