### PR TITLE
[Feature] Add protection metadata for volumes and chunks

### DIFF
--- a/internal/chunk/chunk.go
+++ b/internal/chunk/chunk.go
@@ -5,6 +5,8 @@ import (
 	"encoding/hex"
 	"fmt"
 	"hash/crc32"
+
+	"github.com/piwi3910/novastor/internal/metadata"
 )
 
 const ChunkSize = 4 * 1024 * 1024
@@ -20,6 +22,12 @@ type Chunk struct {
 	ID       ChunkID
 	Data     []byte
 	Checksum uint32
+
+	// ProtectionProfile specifies the data protection settings for this chunk.
+	ProtectionProfile *metadata.ProtectionProfile `json:"protectionProfile,omitempty"`
+
+	// ComplianceInfo tracks the current compliance state of this chunk.
+	ComplianceInfo *metadata.ComplianceInfo `json:"complianceInfo,omitempty"`
 }
 
 func (c *Chunk) ComputeChecksum() uint32 {

--- a/internal/chunk/chunk_protection_test.go
+++ b/internal/chunk/chunk_protection_test.go
@@ -1,0 +1,237 @@
+package chunk
+
+import (
+	"testing"
+
+	"github.com/piwi3910/novastor/internal/metadata"
+)
+
+func TestChunk_WithProtectionProfile(t *testing.T) {
+	data := []byte("test data for protection")
+	chunks := SplitData(data)
+	if len(chunks) != 1 {
+		t.Fatalf("expected 1 chunk, got %d", len(chunks))
+	}
+
+	c := chunks[0]
+
+	// Set a replication protection profile
+	c.ProtectionProfile = &metadata.ProtectionProfile{
+		Mode: metadata.ProtectionModeReplication,
+		Replication: &metadata.ReplicationProfile{
+			Factor:      3,
+			WriteQuorum: 2,
+		},
+	}
+
+	if c.ProtectionProfile == nil {
+		t.Error("expected protection profile to be set")
+	}
+	if c.ProtectionProfile.Mode != metadata.ProtectionModeReplication {
+		t.Errorf("expected replication mode, got %v", c.ProtectionProfile.Mode)
+	}
+	if c.ProtectionProfile.Replication.Factor != 3 {
+		t.Errorf("expected factor 3, got %d", c.ProtectionProfile.Replication.Factor)
+	}
+}
+
+func TestChunk_WithComplianceInfo(t *testing.T) {
+	data := []byte("test data for compliance")
+	chunks := SplitData(data)
+	if len(chunks) != 1 {
+		t.Fatalf("expected 1 chunk, got %d", len(chunks))
+	}
+
+	c := chunks[0]
+
+	// Set compliance info
+	c.ComplianceInfo = &metadata.ComplianceInfo{
+		State:             metadata.ComplianceStateCompliant,
+		AvailableReplicas: 3,
+		RequiredReplicas:  2,
+		Reason:            "All replicas available",
+	}
+
+	if c.ComplianceInfo == nil {
+		t.Error("expected compliance info to be set")
+	}
+	if c.ComplianceInfo.State != metadata.ComplianceStateCompliant {
+		t.Errorf("expected compliant state, got %v", c.ComplianceInfo.State)
+	}
+	if c.ComplianceInfo.AvailableReplicas != 3 {
+		t.Errorf("expected 3 available replicas, got %d", c.ComplianceInfo.AvailableReplicas)
+	}
+}
+
+func TestChunk_WithErasureCoding(t *testing.T) {
+	data := make([]byte, ChunkSize)
+	chunks := SplitData(data)
+	if len(chunks) != 1 {
+		t.Fatalf("expected 1 chunk, got %d", len(chunks))
+	}
+
+	c := chunks[0]
+
+	// Set erasure coding protection profile
+	c.ProtectionProfile = &metadata.ProtectionProfile{
+		Mode: metadata.ProtectionModeErasureCoding,
+		ErasureCoding: &metadata.ErasureCodingProfile{
+			DataShards:   4,
+			ParityShards: 2,
+		},
+	}
+
+	if c.ProtectionProfile.Mode != metadata.ProtectionModeErasureCoding {
+		t.Errorf("expected erasure coding mode, got %v", c.ProtectionProfile.Mode)
+	}
+	if c.ProtectionProfile.ErasureCoding.DataShards != 4 {
+		t.Errorf("expected 4 data shards, got %d", c.ProtectionProfile.ErasureCoding.DataShards)
+	}
+	if c.ProtectionProfile.ErasureCoding.ParityShards != 2 {
+		t.Errorf("expected 2 parity shards, got %d", c.ProtectionProfile.ErasureCoding.ParityShards)
+	}
+}
+
+func TestChunk_RequiredReplicas(t *testing.T) {
+	data := []byte("test data")
+	c := &Chunk{
+		ID:       NewChunkID(data),
+		Data:     data,
+		Checksum: 0,
+	}
+
+	tests := []struct {
+		name     string
+		profile  *metadata.ProtectionProfile
+		expected int
+	}{
+		{
+			name:     "nil profile defaults to 1",
+			profile:  nil,
+			expected: 1,
+		},
+		{
+			name: "replication with explicit quorum",
+			profile: &metadata.ProtectionProfile{
+				Mode: metadata.ProtectionModeReplication,
+				Replication: &metadata.ReplicationProfile{
+					Factor:      5,
+					WriteQuorum: 3,
+				},
+			},
+			expected: 3,
+		},
+		{
+			name: "replication with default quorum",
+			profile: &metadata.ProtectionProfile{
+				Mode: metadata.ProtectionModeReplication,
+				Replication: &metadata.ReplicationProfile{
+					Factor: 3,
+				},
+			},
+			expected: 2, // (3/2)+1
+		},
+		{
+			name: "erasure coding needs data shards",
+			profile: &metadata.ProtectionProfile{
+				Mode: metadata.ProtectionModeErasureCoding,
+				ErasureCoding: &metadata.ErasureCodingProfile{
+					DataShards:   6,
+					ParityShards: 3,
+				},
+			},
+			expected: 6,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c.ProtectionProfile = tt.profile
+			got := c.ProtectionProfile.RequiredReplicas()
+			if got != tt.expected {
+				t.Errorf("RequiredReplicas() = %d, want %d", got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestChunk_TargetReplicas(t *testing.T) {
+	data := []byte("test data")
+	c := &Chunk{
+		ID:       NewChunkID(data),
+		Data:     data,
+		Checksum: 0,
+	}
+
+	tests := []struct {
+		name     string
+		profile  *metadata.ProtectionProfile
+		expected int
+	}{
+		{
+			name:     "nil profile defaults to 1",
+			profile:  nil,
+			expected: 1,
+		},
+		{
+			name: "replication factor",
+			profile: &metadata.ProtectionProfile{
+				Mode: metadata.ProtectionModeReplication,
+				Replication: &metadata.ReplicationProfile{
+					Factor: 5,
+				},
+			},
+			expected: 5,
+		},
+		{
+			name: "erasure coding total shards",
+			profile: &metadata.ProtectionProfile{
+				Mode: metadata.ProtectionModeErasureCoding,
+				ErasureCoding: &metadata.ErasureCodingProfile{
+					DataShards:   4,
+					ParityShards: 2,
+				},
+			},
+			expected: 6, // 4+2
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c.ProtectionProfile = tt.profile
+			got := c.ProtectionProfile.TargetReplicas()
+			if got != tt.expected {
+				t.Errorf("TargetReplicas() = %d, want %d", got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestChunk_UpdateCompliance(t *testing.T) {
+	data := []byte("test data")
+	c := &Chunk{
+		ID:       NewChunkID(data),
+		Data:     data,
+		Checksum: 0,
+		ProtectionProfile: &metadata.ProtectionProfile{
+			Mode: metadata.ProtectionModeReplication,
+			Replication: &metadata.ReplicationProfile{
+				Factor:      3,
+				WriteQuorum: 2,
+			},
+		},
+		ComplianceInfo: &metadata.ComplianceInfo{},
+	}
+
+	metadata.UpdateComplianceState(c.ComplianceInfo, 3, c.ProtectionProfile)
+
+	if c.ComplianceInfo.State != metadata.ComplianceStateCompliant {
+		t.Errorf("expected compliant state, got %v", c.ComplianceInfo.State)
+	}
+	if c.ComplianceInfo.AvailableReplicas != 3 {
+		t.Errorf("expected 3 available replicas, got %d", c.ComplianceInfo.AvailableReplicas)
+	}
+	if c.ComplianceInfo.RequiredReplicas != 2 {
+		t.Errorf("expected 2 required replicas, got %d", c.ComplianceInfo.RequiredReplicas)
+	}
+}

--- a/internal/metadata/protection.go
+++ b/internal/metadata/protection.go
@@ -1,0 +1,224 @@
+package metadata
+
+import (
+	"fmt"
+
+	"github.com/piwi3910/novastor/api/v1alpha1"
+)
+
+// ProtectionMode represents the data protection mode.
+type ProtectionMode string
+
+const (
+	// ProtectionModeReplication uses synchronous replication for data protection.
+	ProtectionModeReplication ProtectionMode = "replication"
+	// ProtectionModeErasureCoding uses Reed-Solomon erasure coding for data protection.
+	ProtectionModeErasureCoding ProtectionMode = "erasureCoding"
+)
+
+// ProtectionProfile captures the data protection settings for a volume or chunk.
+// It specifies how data is protected across nodes (replication or erasure coding).
+type ProtectionProfile struct {
+	// Mode is the protection mode: replication or erasureCoding.
+	Mode ProtectionMode `json:"mode"`
+
+	// Replication holds replication-specific settings when Mode is replication.
+	Replication *ReplicationProfile `json:"replication,omitempty"`
+
+	// ErasureCoding holds erasure coding-specific settings when Mode is erasureCoding.
+	ErasureCoding *ErasureCodingProfile `json:"erasureCoding,omitempty"`
+}
+
+// ReplicationProfile defines synchronous replication parameters.
+type ReplicationProfile struct {
+	// Factor is the number of replicas to maintain (e.g., 3 for 3-way replication).
+	Factor int `json:"factor"`
+
+	// WriteQuorum is the minimum number of successful writes required for a write to complete.
+	// Defaults to majority (factor/2 + 1) if not specified.
+	WriteQuorum int `json:"writeQuorum,omitempty"`
+}
+
+// ErasureCodingProfile defines Reed-Solomon erasure coding parameters.
+type ErasureCodingProfile struct {
+	// DataShards is the number of data shards (e.g., 4).
+	DataShards int `json:"dataShards"`
+
+	// ParityShards is the number of parity shards (e.g., 2 for 4+2 encoding).
+	ParityShards int `json:"parityShards"`
+}
+
+// ComplianceState represents the compliance state of a volume or chunk.
+type ComplianceState string
+
+const (
+	// ComplianceStateUnknown means the compliance state has not been determined.
+	ComplianceStateUnknown ComplianceState = "unknown"
+	// ComplianceStateCompliant means the volume/chunk meets all protection requirements.
+	ComplianceStateCompliant ComplianceState = "compliant"
+	// ComplianceStateDegraded means the volume/chunk is operational but below optimal redundancy.
+	ComplianceStateDegraded ComplianceState = "degraded"
+	// ComplianceStateNonCompliant means the volume/chunk does not meet protection requirements.
+	ComplianceStateNonCompliant ComplianceState = "nonCompliant"
+)
+
+// ComplianceInfo tracks the compliance state and related metrics.
+type ComplianceInfo struct {
+	// State is the current compliance state.
+	State ComplianceState `json:"state"`
+
+	// LastCheckTime is the Unix timestamp (nanoseconds) of the last compliance check.
+	LastCheckTime int64 `json:"lastCheckTime,omitempty"`
+
+	// AvailableReplicas is the current number of available replicas.
+	AvailableReplicas int `json:"availableReplicas,omitempty"`
+
+	// RequiredReplicas is the minimum number of replicas required for compliance.
+	RequiredReplicas int `json:"requiredReplicas,omitempty"`
+
+	// Reason provides a human-readable explanation for the current state.
+	Reason string `json:"reason,omitempty"`
+}
+
+// NewProtectionProfileFromV1Alpha1 converts a v1alpha1 DataProtectionSpec to a ProtectionProfile.
+func NewProtectionProfileFromV1Alpha1(spec *v1alpha1.DataProtectionSpec) *ProtectionProfile {
+	if spec == nil {
+		return nil
+	}
+
+	profile := &ProtectionProfile{
+		Mode: ProtectionMode(spec.Mode),
+	}
+
+	switch ProtectionMode(spec.Mode) {
+	case ProtectionModeReplication:
+		if spec.Replication != nil {
+			profile.Replication = &ReplicationProfile{
+				Factor:      spec.Replication.Factor,
+				WriteQuorum: spec.Replication.WriteQuorum,
+			}
+		}
+	case ProtectionModeErasureCoding:
+		if spec.ErasureCoding != nil {
+			profile.ErasureCoding = &ErasureCodingProfile{
+				DataShards:   spec.ErasureCoding.DataShards,
+				ParityShards: spec.ErasureCoding.ParityShards,
+			}
+		}
+	}
+
+	return profile
+}
+
+// Validate checks if the ProtectionProfile is valid.
+func (p *ProtectionProfile) Validate() error {
+	if p == nil {
+		return fmt.Errorf("protection profile is nil")
+	}
+
+	switch p.Mode {
+	case ProtectionModeReplication:
+		if p.Replication == nil {
+			return fmt.Errorf("replication mode requires replication profile")
+		}
+		if p.Replication.Factor < 1 || p.Replication.Factor > 5 {
+			return fmt.Errorf("replication factor must be between 1 and 5, got %d", p.Replication.Factor)
+		}
+		if p.Replication.WriteQuorum < 0 {
+			return fmt.Errorf("write quorum cannot be negative, got %d", p.Replication.WriteQuorum)
+		}
+		if p.Replication.WriteQuorum > p.Replication.Factor {
+			return fmt.Errorf("write quorum (%d) cannot exceed replication factor (%d)",
+				p.Replication.WriteQuorum, p.Replication.Factor)
+		}
+	case ProtectionModeErasureCoding:
+		if p.ErasureCoding == nil {
+			return fmt.Errorf("erasure coding mode requires erasure coding profile")
+		}
+		if p.ErasureCoding.DataShards < 2 {
+			return fmt.Errorf("data shards must be at least 2, got %d", p.ErasureCoding.DataShards)
+		}
+		if p.ErasureCoding.ParityShards < 1 {
+			return fmt.Errorf("parity shards must be at least 1, got %d", p.ErasureCoding.ParityShards)
+		}
+	default:
+		return fmt.Errorf("unknown protection mode: %s", p.Mode)
+	}
+
+	return nil
+}
+
+// RequiredReplicas returns the minimum number of replicas required for compliance.
+func (p *ProtectionProfile) RequiredReplicas() int {
+	if p == nil {
+		return 1
+	}
+
+	switch p.Mode {
+	case ProtectionModeReplication:
+		if p.Replication != nil && p.Replication.WriteQuorum > 0 {
+			return p.Replication.WriteQuorum
+		}
+		if p.Replication != nil {
+			// Default to majority
+			return (p.Replication.Factor / 2) + 1
+		}
+		return 1
+	case ProtectionModeErasureCoding:
+		if p.ErasureCoding != nil {
+			// Need at least dataShards to reconstruct
+			return p.ErasureCoding.DataShards
+		}
+		return 1
+	default:
+		return 1
+	}
+}
+
+// TargetReplicas returns the target number of replicas for optimal redundancy.
+func (p *ProtectionProfile) TargetReplicas() int {
+	if p == nil {
+		return 1
+	}
+
+	switch p.Mode {
+	case ProtectionModeReplication:
+		if p.Replication != nil {
+			return p.Replication.Factor
+		}
+		return 1
+	case ProtectionModeErasureCoding:
+		if p.ErasureCoding != nil {
+			// Total shards = data + parity
+			return p.ErasureCoding.DataShards + p.ErasureCoding.ParityShards
+		}
+		return 1
+	default:
+		return 1
+	}
+}
+
+// UpdateComplianceState updates the ComplianceInfo based on available replicas.
+func UpdateComplianceState(info *ComplianceInfo, availableReplicas int, profile *ProtectionProfile) {
+	if info == nil {
+		return
+	}
+
+	required := profile.RequiredReplicas()
+	target := profile.TargetReplicas()
+
+	info.AvailableReplicas = availableReplicas
+	info.RequiredReplicas = required
+
+	switch {
+	case availableReplicas >= target:
+		info.State = ComplianceStateCompliant
+		info.Reason = fmt.Sprintf("All %d replicas available", target)
+	case availableReplicas >= required:
+		info.State = ComplianceStateDegraded
+		info.Reason = fmt.Sprintf("%d of %d replicas available (degraded)", availableReplicas, target)
+	default:
+		info.State = ComplianceStateNonCompliant
+		info.Reason = fmt.Sprintf("Only %d of %d required replicas available", availableReplicas, required)
+	}
+}

--- a/internal/metadata/protection_test.go
+++ b/internal/metadata/protection_test.go
@@ -1,0 +1,421 @@
+package metadata
+
+import (
+	"testing"
+
+	"github.com/piwi3910/novastor/api/v1alpha1"
+)
+
+func TestProtectionProfile_Validate(t *testing.T) {
+	tests := []struct {
+		name    string
+		profile *ProtectionProfile
+		wantErr bool
+	}{
+		{
+			name:    "nil profile",
+			profile: nil,
+			wantErr: true,
+		},
+		{
+			name: "valid replication profile",
+			profile: &ProtectionProfile{
+				Mode: ProtectionModeReplication,
+				Replication: &ReplicationProfile{
+					Factor:      3,
+					WriteQuorum: 2,
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "replication mode without profile",
+			profile: &ProtectionProfile{
+				Mode: ProtectionModeReplication,
+			},
+			wantErr: true,
+		},
+		{
+			name: "replication factor too high",
+			profile: &ProtectionProfile{
+				Mode: ProtectionModeReplication,
+				Replication: &ReplicationProfile{
+					Factor: 6,
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "replication factor zero",
+			profile: &ProtectionProfile{
+				Mode: ProtectionModeReplication,
+				Replication: &ReplicationProfile{
+					Factor: 0,
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "write quorum exceeds factor",
+			profile: &ProtectionProfile{
+				Mode: ProtectionModeReplication,
+				Replication: &ReplicationProfile{
+					Factor:      3,
+					WriteQuorum: 4,
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "negative write quorum",
+			profile: &ProtectionProfile{
+				Mode: ProtectionModeReplication,
+				Replication: &ReplicationProfile{
+					Factor:      3,
+					WriteQuorum: -1,
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "valid erasure coding profile",
+			profile: &ProtectionProfile{
+				Mode: ProtectionModeErasureCoding,
+				ErasureCoding: &ErasureCodingProfile{
+					DataShards:   4,
+					ParityShards: 2,
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "erasure coding mode without profile",
+			profile: &ProtectionProfile{
+				Mode: ProtectionModeErasureCoding,
+			},
+			wantErr: true,
+		},
+		{
+			name: "data shards too few",
+			profile: &ProtectionProfile{
+				Mode: ProtectionModeErasureCoding,
+				ErasureCoding: &ErasureCodingProfile{
+					DataShards:   1,
+					ParityShards: 2,
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "parity shards zero",
+			profile: &ProtectionProfile{
+				Mode: ProtectionModeErasureCoding,
+				ErasureCoding: &ErasureCodingProfile{
+					DataShards:   4,
+					ParityShards: 0,
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "unknown mode",
+			profile: &ProtectionProfile{
+				Mode: ProtectionMode("unknown"),
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.profile.Validate()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Validate() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestProtectionProfile_RequiredReplicas(t *testing.T) {
+	tests := []struct {
+		name    string
+		profile *ProtectionProfile
+		want    int
+	}{
+		{
+			name:    "nil profile",
+			profile: nil,
+			want:    1,
+		},
+		{
+			name: "replication with explicit quorum",
+			profile: &ProtectionProfile{
+				Mode: ProtectionModeReplication,
+				Replication: &ReplicationProfile{
+					Factor:      3,
+					WriteQuorum: 2,
+				},
+			},
+			want: 2,
+		},
+		{
+			name: "replication with default quorum (majority)",
+			profile: &ProtectionProfile{
+				Mode: ProtectionModeReplication,
+				Replication: &ReplicationProfile{
+					Factor: 3,
+				},
+			},
+			want: 2, // (3/2)+1 = 2
+		},
+		{
+			name: "replication factor 5",
+			profile: &ProtectionProfile{
+				Mode: ProtectionModeReplication,
+				Replication: &ReplicationProfile{
+					Factor: 5,
+				},
+			},
+			want: 3, // (5/2)+1 = 3
+		},
+		{
+			name: "erasure coding 4+2",
+			profile: &ProtectionProfile{
+				Mode: ProtectionModeErasureCoding,
+				ErasureCoding: &ErasureCodingProfile{
+					DataShards:   4,
+					ParityShards: 2,
+				},
+			},
+			want: 4, // need all data shards
+		},
+		{
+			name: "erasure coding 8+3",
+			profile: &ProtectionProfile{
+				Mode: ProtectionModeErasureCoding,
+				ErasureCoding: &ErasureCodingProfile{
+					DataShards:   8,
+					ParityShards: 3,
+				},
+			},
+			want: 8,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.profile.RequiredReplicas(); got != tt.want {
+				t.Errorf("RequiredReplicas() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestProtectionProfile_TargetReplicas(t *testing.T) {
+	tests := []struct {
+		name    string
+		profile *ProtectionProfile
+		want    int
+	}{
+		{
+			name:    "nil profile",
+			profile: nil,
+			want:    1,
+		},
+		{
+			name: "replication factor 3",
+			profile: &ProtectionProfile{
+				Mode: ProtectionModeReplication,
+				Replication: &ReplicationProfile{
+					Factor: 3,
+				},
+			},
+			want: 3,
+		},
+		{
+			name: "replication factor 5",
+			profile: &ProtectionProfile{
+				Mode: ProtectionModeReplication,
+				Replication: &ReplicationProfile{
+					Factor: 5,
+				},
+			},
+			want: 5,
+		},
+		{
+			name: "erasure coding 4+2",
+			profile: &ProtectionProfile{
+				Mode: ProtectionModeErasureCoding,
+				ErasureCoding: &ErasureCodingProfile{
+					DataShards:   4,
+					ParityShards: 2,
+				},
+			},
+			want: 6, // 4+2
+		},
+		{
+			name: "erasure coding 8+3",
+			profile: &ProtectionProfile{
+				Mode: ProtectionModeErasureCoding,
+				ErasureCoding: &ErasureCodingProfile{
+					DataShards:   8,
+					ParityShards: 3,
+				},
+			},
+			want: 11, // 8+3
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.profile.TargetReplicas(); got != tt.want {
+				t.Errorf("TargetReplicas() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestNewProtectionProfileFromV1Alpha1(t *testing.T) {
+	tests := []struct {
+		name string
+		spec *v1alpha1.DataProtectionSpec
+		want *ProtectionProfile
+	}{
+		{
+			name: "nil spec",
+			spec: nil,
+			want: nil,
+		},
+		{
+			name: "replication mode",
+			spec: &v1alpha1.DataProtectionSpec{
+				Mode: "replication",
+				Replication: &v1alpha1.ReplicationSpec{
+					Factor:      3,
+					WriteQuorum: 2,
+				},
+			},
+			want: &ProtectionProfile{
+				Mode: ProtectionModeReplication,
+				Replication: &ReplicationProfile{
+					Factor:      3,
+					WriteQuorum: 2,
+				},
+			},
+		},
+		{
+			name: "erasure coding mode",
+			spec: &v1alpha1.DataProtectionSpec{
+				Mode: "erasureCoding",
+				ErasureCoding: &v1alpha1.ErasureCodingSpec{
+					DataShards:   4,
+					ParityShards: 2,
+				},
+			},
+			want: &ProtectionProfile{
+				Mode: ProtectionModeErasureCoding,
+				ErasureCoding: &ErasureCodingProfile{
+					DataShards:   4,
+					ParityShards: 2,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := NewProtectionProfileFromV1Alpha1(tt.spec)
+			if got == nil && tt.want == nil {
+				return
+			}
+			if got == nil || tt.want == nil {
+				t.Fatalf("NewProtectionProfileFromV1Alpha1() = %v, want %v", got, tt.want)
+			}
+			if got.Mode != tt.want.Mode {
+				t.Errorf("Mode = %v, want %v", got.Mode, tt.want.Mode)
+			}
+			if got.Replication != nil && tt.want.Replication != nil {
+				if got.Replication.Factor != tt.want.Replication.Factor {
+					t.Errorf("Replication.Factor = %v, want %v", got.Replication.Factor, tt.want.Replication.Factor)
+				}
+				if got.Replication.WriteQuorum != tt.want.Replication.WriteQuorum {
+					t.Errorf("Replication.WriteQuorum = %v, want %v", got.Replication.WriteQuorum, tt.want.Replication.WriteQuorum)
+				}
+			}
+			if got.ErasureCoding != nil && tt.want.ErasureCoding != nil {
+				if got.ErasureCoding.DataShards != tt.want.ErasureCoding.DataShards {
+					t.Errorf("ErasureCoding.DataShards = %v, want %v", got.ErasureCoding.DataShards, tt.want.ErasureCoding.DataShards)
+				}
+				if got.ErasureCoding.ParityShards != tt.want.ErasureCoding.ParityShards {
+					t.Errorf("ErasureCoding.ParityShards = %v, want %v", got.ErasureCoding.ParityShards, tt.want.ErasureCoding.ParityShards)
+				}
+			}
+		})
+	}
+}
+
+func TestUpdateComplianceState(t *testing.T) {
+	profile := &ProtectionProfile{
+		Mode: ProtectionModeReplication,
+		Replication: &ReplicationProfile{
+			Factor:      3,
+			WriteQuorum: 2,
+		},
+	}
+
+	tests := []struct {
+		name              string
+		info              ComplianceInfo
+		availableReplicas int
+		wantState         ComplianceState
+		wantReason        string
+	}{
+		{
+			name:              "fully compliant",
+			info:              ComplianceInfo{},
+			availableReplicas: 3,
+			wantState:         ComplianceStateCompliant,
+			wantReason:        "All 3 replicas available",
+		},
+		{
+			name:              "degraded",
+			info:              ComplianceInfo{},
+			availableReplicas: 2,
+			wantState:         ComplianceStateDegraded,
+			wantReason:        "2 of 3 replicas available (degraded)",
+		},
+		{
+			name:              "non-compliant",
+			info:              ComplianceInfo{},
+			availableReplicas: 1,
+			wantState:         ComplianceStateNonCompliant,
+			wantReason:        "Only 1 of 2 required replicas available",
+		},
+		{
+			name:              "zero replicas",
+			info:              ComplianceInfo{},
+			availableReplicas: 0,
+			wantState:         ComplianceStateNonCompliant,
+			wantReason:        "Only 0 of 2 required replicas available",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			info := tt.info // Create a copy to modify
+			UpdateComplianceState(&info, tt.availableReplicas, profile)
+			if info.State != tt.wantState {
+				t.Errorf("State = %v, want %v", info.State, tt.wantState)
+			}
+			if info.Reason != tt.wantReason {
+				t.Errorf("Reason = %v, want %v", info.Reason, tt.wantReason)
+			}
+			if info.AvailableReplicas != tt.availableReplicas {
+				t.Errorf("AvailableReplicas = %v, want %v", info.AvailableReplicas, tt.availableReplicas)
+			}
+			if info.RequiredReplicas != 2 {
+				t.Errorf("RequiredReplicas = %v, want 2", info.RequiredReplicas)
+			}
+		})
+	}
+}

--- a/internal/metadata/store.go
+++ b/internal/metadata/store.go
@@ -27,6 +27,12 @@ type VolumeMeta struct {
 	TargetAddress string `json:"targetAddress,omitempty"`
 	TargetPort    string `json:"targetPort,omitempty"`
 	SubsystemNQN  string `json:"subsystemNQN,omitempty"`
+
+	// ProtectionProfile specifies the data protection settings for this volume.
+	ProtectionProfile *ProtectionProfile `json:"protectionProfile,omitempty"`
+
+	// ComplianceInfo tracks the current compliance state of this volume.
+	ComplianceInfo *ComplianceInfo `json:"complianceInfo,omitempty"`
 }
 
 type PlacementMap struct {

--- a/internal/metadata/store_test.go
+++ b/internal/metadata/store_test.go
@@ -106,3 +106,165 @@ func TestRaftStore_PutGetPlacementMap(t *testing.T) {
 		t.Errorf("expected 3 nodes, got %d", len(got.Nodes))
 	}
 }
+
+func TestRaftStore_VolumeMetaWithProtection(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	meta := &VolumeMeta{
+		VolumeID:  "vol-protected",
+		Pool:      "fast-pool",
+		SizeBytes: 1024 * 1024 * 1024,
+		ChunkIDs:  []string{"chunk-a", "chunk-b"},
+		ProtectionProfile: &ProtectionProfile{
+			Mode: ProtectionModeReplication,
+			Replication: &ReplicationProfile{
+				Factor:      3,
+				WriteQuorum: 2,
+			},
+		},
+		ComplianceInfo: &ComplianceInfo{
+			State:             ComplianceStateCompliant,
+			AvailableReplicas: 3,
+			RequiredReplicas:  2,
+			Reason:            "All replicas available",
+		},
+	}
+
+	if err := store.PutVolumeMeta(ctx, meta); err != nil {
+		t.Fatalf("PutVolumeMeta failed: %v", err)
+	}
+
+	got, err := store.GetVolumeMeta(ctx, "vol-protected")
+	if err != nil {
+		t.Fatalf("GetVolumeMeta failed: %v", err)
+	}
+
+	if got.ProtectionProfile == nil {
+		t.Fatal("expected protection profile to be persisted")
+	}
+	if got.ProtectionProfile.Mode != ProtectionModeReplication {
+		t.Errorf("expected replication mode, got %v", got.ProtectionProfile.Mode)
+	}
+	if got.ProtectionProfile.Replication.Factor != 3 {
+		t.Errorf("expected factor 3, got %d", got.ProtectionProfile.Replication.Factor)
+	}
+	if got.ComplianceInfo == nil {
+		t.Fatal("expected compliance info to be persisted")
+	}
+	if got.ComplianceInfo.State != ComplianceStateCompliant {
+		t.Errorf("expected compliant state, got %v", got.ComplianceInfo.State)
+	}
+}
+
+func TestRaftStore_VolumeMetaWithErasureCoding(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	meta := &VolumeMeta{
+		VolumeID:  "vol-ec",
+		Pool:      "capacity-pool",
+		SizeBytes: 2 * 1024 * 1024 * 1024,
+		ChunkIDs:  []string{"chunk-1", "chunk-2", "chunk-3"},
+		ProtectionProfile: &ProtectionProfile{
+			Mode: ProtectionModeErasureCoding,
+			ErasureCoding: &ErasureCodingProfile{
+				DataShards:   4,
+				ParityShards: 2,
+			},
+		},
+	}
+
+	if err := store.PutVolumeMeta(ctx, meta); err != nil {
+		t.Fatalf("PutVolumeMeta failed: %v", err)
+	}
+
+	got, err := store.GetVolumeMeta(ctx, "vol-ec")
+	if err != nil {
+		t.Fatalf("GetVolumeMeta failed: %v", err)
+	}
+
+	if got.ProtectionProfile.Mode != ProtectionModeErasureCoding {
+		t.Errorf("expected erasure coding mode, got %v", got.ProtectionProfile.Mode)
+	}
+	if got.ProtectionProfile.ErasureCoding.DataShards != 4 {
+		t.Errorf("expected 4 data shards, got %d", got.ProtectionProfile.ErasureCoding.DataShards)
+	}
+	if got.ProtectionProfile.ErasureCoding.ParityShards != 2 {
+		t.Errorf("expected 2 parity shards, got %d", got.ProtectionProfile.ErasureCoding.ParityShards)
+	}
+}
+
+func TestRaftStore_ListVolumesWithProtection(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	// Create volumes with different protection profiles
+	volumes := []*VolumeMeta{
+		{
+			VolumeID: "vol-repl",
+			Pool:     "default",
+			ChunkIDs: []string{"chunk-1"},
+			ProtectionProfile: &ProtectionProfile{
+				Mode: ProtectionModeReplication,
+				Replication: &ReplicationProfile{
+					Factor: 3,
+				},
+			},
+		},
+		{
+			VolumeID: "vol-ec",
+			Pool:     "default",
+			ChunkIDs: []string{"chunk-2"},
+			ProtectionProfile: &ProtectionProfile{
+				Mode: ProtectionModeErasureCoding,
+				ErasureCoding: &ErasureCodingProfile{
+					DataShards:   4,
+					ParityShards: 2,
+				},
+			},
+		},
+		{
+			VolumeID: "vol-none",
+			Pool:     "default",
+			ChunkIDs: []string{"chunk-3"},
+			// No protection profile
+		},
+	}
+
+	for _, v := range volumes {
+		if err := store.PutVolumeMeta(ctx, v); err != nil {
+			t.Fatalf("PutVolumeMeta failed: %v", err)
+		}
+	}
+
+	listed, err := store.ListVolumesMeta(ctx)
+	if err != nil {
+		t.Fatalf("ListVolumesMeta failed: %v", err)
+	}
+
+	if len(listed) != 3 {
+		t.Errorf("expected 3 volumes, got %d", len(listed))
+	}
+
+	// Verify each volume's protection profile was persisted
+	for _, v := range listed {
+		switch v.VolumeID {
+		case "vol-repl":
+			if v.ProtectionProfile == nil || v.ProtectionProfile.Mode != ProtectionModeReplication {
+				t.Errorf("vol-repl: expected replication mode")
+			}
+		case "vol-ec":
+			if v.ProtectionProfile == nil || v.ProtectionProfile.Mode != ProtectionModeErasureCoding {
+				t.Errorf("vol-ec: expected erasure coding mode")
+			}
+		case "vol-none":
+			if v.ProtectionProfile != nil {
+				t.Errorf("vol-none: expected no protection profile, got %v", v.ProtectionProfile)
+			}
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Add ProtectionProfile and ComplianceInfo types to track data protection settings and compliance state for volumes and chunks.

## Changes

- Add `ProtectionProfile` struct with replication and erasure coding modes
- Add `ComplianceInfo` struct to track state, replicas, and reason
- Extend `VolumeMeta` with `ProtectionProfile` and `ComplianceInfo` fields
- Extend `Chunk` struct with `ProtectionProfile` and `ComplianceInfo` fields
- Add `RequiredReplicas()` and `TargetReplicas()` helper methods
- Add `Validate()` method for protection profiles
- Add `UpdateComplianceState()` function to update compliance info
- Add `NewProtectionProfileFromV1Alpha1()` to convert API spec
- Add comprehensive tests for all new functionality

## Protection Modes

### Replication
- Factor: Number of replicas to maintain (1-5)
- WriteQuorum: Minimum successful writes required (defaults to majority)

### Erasure Coding
- DataShards: Number of data shards (minimum 2)
- ParityShards: Number of parity shards (minimum 1)

## Compliance States

- **Compliant**: All target replicas available
- **Degraded**: Below target but above required quorum
- **NonCompliant**: Below required quorum

## Testing

All tests pass with comprehensive coverage:
- Protection profile validation
- Required/Target replica calculations
- Compliance state updates
- Volume metadata persistence
- Chunk metadata with protection

Resolves #34