### PR TITLE
[Feature] Add pluggable backend factory with conformance test suite

### DIFF
--- a/internal/chunk/backend_factory.go
+++ b/internal/chunk/backend_factory.go
@@ -1,0 +1,74 @@
+package chunk
+
+import (
+	"fmt"
+	"sync"
+)
+
+// BackendFactory creates a Store instance from a configuration.
+type BackendFactory func(config map[string]string) (Store, error)
+
+// backendRegistry holds registered backend factories.
+var (
+	backendRegistry = make(map[string]BackendFactory)
+	registryMutex   sync.RWMutex
+)
+
+// RegisterBackend registers a backend factory for a given backend type.
+// Panics if a factory with the same name is already registered.
+// This function is typically called in init() functions of backend packages.
+func RegisterBackend(name string, factory BackendFactory) {
+	registryMutex.Lock()
+	defer registryMutex.Unlock()
+	if _, exists := backendRegistry[name]; exists {
+		panic(fmt.Sprintf("backend %q already registered", name))
+	}
+	backendRegistry[name] = factory
+}
+
+// CreateBackend creates a new Store instance of the specified backend type.
+// The config parameter provides backend-specific configuration options.
+// Returns an error if the backend type is not registered.
+func CreateBackend(backendType string, config map[string]string) (Store, error) {
+	registryMutex.RLock()
+	factory, exists := backendRegistry[backendType]
+	registryMutex.RUnlock()
+
+	if !exists {
+		return nil, fmt.Errorf("backend type %q not registered (available: %v)", backendType, GetRegisteredBackends())
+	}
+
+	return factory(config)
+}
+
+// GetRegisteredBackends returns a list of all registered backend names.
+func GetRegisteredBackends() []string {
+	registryMutex.RLock()
+	defer registryMutex.RUnlock()
+
+	names := make([]string, 0, len(backendRegistry))
+	for name := range backendRegistry {
+		names = append(names, name)
+	}
+	return names
+}
+
+// init registers built-in backend factories.
+func init() {
+	// Register the local filesystem backend.
+	RegisterBackend("local", func(config map[string]string) (Store, error) {
+		dir := config["dir"]
+		if dir == "" {
+			dir = config["path"]
+		}
+		if dir == "" {
+			return nil, fmt.Errorf("local backend requires 'dir' or 'path' config")
+		}
+		return NewLocalStore(dir)
+	})
+
+	// Register the in-memory backend.
+	RegisterBackend("memory", func(config map[string]string) (Store, error) {
+		return NewMemoryStore(), nil
+	})
+}

--- a/internal/chunk/backend_factory_test.go
+++ b/internal/chunk/backend_factory_test.go
@@ -1,0 +1,175 @@
+package chunk
+
+import (
+	"context"
+	"testing"
+)
+
+func TestRegisterBackend(t *testing.T) {
+	// Create a unique backend name for testing.
+	testName := "test-backend-" + string(NewChunkID([]byte("test")))
+
+	// Define a simple factory.
+	factory := func(config map[string]string) (Store, error) {
+		return NewMemoryStore(), nil
+	}
+
+	// Register the backend.
+	RegisterBackend(testName, factory)
+
+	// Verify it's in the registry.
+	registered := GetRegisteredBackends()
+	found := false
+	for _, name := range registered {
+		if name == testName {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("registered backend %q not found in %v", testName, registered)
+	}
+
+	// Verify we can create an instance.
+	store, err := CreateBackend(testName, nil)
+	if err != nil {
+		t.Fatalf("CreateBackend failed: %v", err)
+	}
+	if store == nil {
+		t.Error("CreateBackend returned nil store")
+	}
+
+	// Verify the store works.
+	ctx := context.Background()
+	data := []byte("test data")
+	chunks := SplitData(data)
+	if len(chunks) != 1 {
+		t.Fatalf("expected 1 chunk, got %d", len(chunks))
+	}
+	if err := store.Put(ctx, chunks[0]); err != nil {
+		t.Errorf("store.Put failed: %v", err)
+	}
+}
+
+func TestRegisterBackendDuplicate(t *testing.T) {
+	// This test verifies that registering a duplicate backend panics.
+	// We can't run this in the same process as it would crash the test runner.
+	// Instead, we document the expected behavior.
+	t.Skip("registering a duplicate backend should panic")
+}
+
+func TestCreateBackendUnknown(t *testing.T) {
+	_, err := CreateBackend("unknown-backend-type", nil)
+	if err == nil {
+		t.Error("expected error for unknown backend type, got nil")
+	}
+}
+
+func TestCreateBackendLocal(t *testing.T) {
+	// Test the built-in local backend.
+	tempDir := t.TempDir()
+	store, err := CreateBackend("local", map[string]string{"dir": tempDir})
+	if err != nil {
+		t.Fatalf("CreateBackend failed: %v", err)
+	}
+	if store == nil {
+		t.Fatal("CreateBackend returned nil store")
+	}
+
+	// Verify it's a LocalStore by exercising it.
+	if _, ok := store.(*LocalStore); !ok {
+		t.Error("expected *LocalStore, got different type")
+	}
+
+	// Verify the store works.
+	ctx := context.Background()
+	data := []byte("test data for local backend")
+	chunks := SplitData(data)
+	if len(chunks) != 1 {
+		t.Fatalf("expected 1 chunk, got %d", len(chunks))
+	}
+	if err := store.Put(ctx, chunks[0]); err != nil {
+		t.Errorf("store.Put failed: %v", err)
+	}
+
+	got, err := store.Get(ctx, chunks[0].ID)
+	if err != nil {
+		t.Errorf("store.Get failed: %v", err)
+	}
+	if string(got.Data) != string(chunks[0].Data) {
+		t.Error("data mismatch")
+	}
+}
+
+func TestCreateBackendLocalMissingConfig(t *testing.T) {
+	// Test that local backend requires dir config.
+	_, err := CreateBackend("local", map[string]string{})
+	if err == nil {
+		t.Error("expected error for missing dir config, got nil")
+	}
+}
+
+func TestCreateBackendMemory(t *testing.T) {
+	// Test the built-in memory backend.
+	store, err := CreateBackend("memory", nil)
+	if err != nil {
+		t.Fatalf("CreateBackend failed: %v", err)
+	}
+	if store == nil {
+		t.Fatal("CreateBackend returned nil store")
+	}
+
+	// Verify it's a MemoryStore.
+	if _, ok := store.(*MemoryStore); !ok {
+		t.Error("expected *MemoryStore, got different type")
+	}
+
+	// Run conformance tests.
+	StoreConformanceTest(store, t)
+}
+
+func TestGetRegisteredBackends(t *testing.T) {
+	backends := GetRegisteredBackends()
+	if len(backends) < 2 {
+		t.Errorf("expected at least 2 built-in backends, got %d", len(backends))
+	}
+
+	// Verify expected backends are present.
+	backendMap := make(map[string]bool)
+	for _, name := range backends {
+		backendMap[name] = true
+	}
+
+	expectedBackends := []string{"local", "memory"}
+	for _, expected := range expectedBackends {
+		if !backendMap[expected] {
+			t.Errorf("expected backend %q not found in %v", expected, backends)
+		}
+	}
+}
+
+func TestBackendFactoryConcurrent(t *testing.T) {
+	// Test that the backend registry is thread-safe.
+	const numGoroutines = 10
+	done := make(chan bool)
+
+	for i := 0; i < numGoroutines; i++ {
+		go func() {
+			// Try to create backends concurrently.
+			_, err := CreateBackend("memory", nil)
+			if err != nil {
+				t.Errorf("CreateBackend failed: %v", err)
+			}
+			backends := GetRegisteredBackends()
+			if len(backends) == 0 {
+				t.Error("GetRegisteredBackends returned empty list")
+			}
+			done <- true
+		}()
+	}
+
+	// Wait for all goroutines.
+	for i := 0; i < numGoroutines; i++ {
+		<-done
+	}
+}

--- a/internal/chunk/conformance_test.go
+++ b/internal/chunk/conformance_test.go
@@ -1,0 +1,356 @@
+package chunk
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+)
+
+// StoreConformanceTest runs a comprehensive suite of tests against a Store implementation.
+// Any backend implementation should pass this test suite to be considered conformant.
+// Note: This test will modify the store. For each test run, create a new store instance.
+func StoreConformanceTest(store Store, t *testing.T) {
+	t.Run("PutGet", func(t *testing.T) { testPutGet(store, t) })
+	t.Run("GetNotFound", func(t *testing.T) { testGetNotFound(store, t) })
+	t.Run("Delete", func(t *testing.T) { testDelete(store, t) })
+	t.Run("DeleteNonexistent", func(t *testing.T) { testDeleteNonexistent(store, t) })
+	t.Run("Has", func(t *testing.T) { testHas(store, t) })
+	t.Run("List", func(t *testing.T) { testList(store, t) })
+	t.Run("ChecksumVerification", func(t *testing.T) { testChecksumVerification(store, t) })
+	t.Run("LargeChunk", func(t *testing.T) { testLargeChunk(store, t) })
+	t.Run("EmptyChunk", func(t *testing.T) { testEmptyChunk(store, t) })
+	t.Run("DuplicatePut", func(t *testing.T) { testDuplicatePut(store, t) })
+	t.Run("ConcurrentOperations", func(t *testing.T) { testConcurrentOperations(store, t) })
+	t.Run("ThreadSafety", func(t *testing.T) { testThreadSafety(store, t) })
+}
+
+func testPutGet(store Store, t *testing.T) {
+	ctx := context.Background()
+	data := []byte("test data for put/get")
+	chunks := SplitData(data)
+	if len(chunks) != 1 {
+		t.Fatalf("expected 1 chunk, got %d", len(chunks))
+	}
+
+	c := chunks[0]
+	if err := store.Put(ctx, c); err != nil {
+		t.Fatalf("Put failed: %v", err)
+	}
+
+	got, err := store.Get(ctx, c.ID)
+	if err != nil {
+		t.Fatalf("Get failed: %v", err)
+	}
+
+	if got.ID != c.ID {
+		t.Errorf("ID mismatch: got %q, want %q", got.ID, c.ID)
+	}
+	if string(got.Data) != string(c.Data) {
+		t.Errorf("Data mismatch: got %q, want %q", got.Data, c.Data)
+	}
+	if got.Checksum != c.Checksum {
+		t.Errorf("Checksum mismatch: got %d, want %d", got.Checksum, c.Checksum)
+	}
+}
+
+func testGetNotFound(store Store, t *testing.T) {
+	ctx := context.Background()
+	_, err := store.Get(ctx, ChunkID("nonexistent"))
+	if err == nil {
+		t.Error("expected error for nonexistent chunk, got nil")
+	}
+}
+
+func testDelete(store Store, t *testing.T) {
+	ctx := context.Background()
+	data := []byte("test data for delete")
+	chunks := SplitData(data)
+	if len(chunks) != 1 {
+		t.Fatalf("expected 1 chunk, got %d", len(chunks))
+	}
+
+	c := chunks[0]
+	if err := store.Put(ctx, c); err != nil {
+		t.Fatalf("Put failed: %v", err)
+	}
+
+	if err := store.Delete(ctx, c.ID); err != nil {
+		t.Fatalf("Delete failed: %v", err)
+	}
+
+	// Verify the chunk is gone.
+	if _, err := store.Get(ctx, c.ID); err == nil {
+		t.Error("expected error getting deleted chunk, got nil")
+	}
+}
+
+func testDeleteNonexistent(store Store, t *testing.T) {
+	ctx := context.Background()
+	// Deleting a nonexistent chunk should not error.
+	if err := store.Delete(ctx, ChunkID("nonexistent")); err != nil {
+		t.Errorf("Delete of nonexistent chunk failed: %v", err)
+	}
+}
+
+func testHas(store Store, t *testing.T) {
+	ctx := context.Background()
+	data := []byte("test data for has")
+	chunks := SplitData(data)
+	if len(chunks) != 1 {
+		t.Fatalf("expected 1 chunk, got %d", len(chunks))
+	}
+
+	c := chunks[0]
+
+	// Chunk should not exist initially.
+	has, err := store.Has(ctx, c.ID)
+	if err != nil {
+		t.Fatalf("Has failed: %v", err)
+	}
+	if has {
+		t.Error("expected Has to return false for nonexistent chunk")
+	}
+
+	// Put the chunk.
+	if err := store.Put(ctx, c); err != nil {
+		t.Fatalf("Put failed: %v", err)
+	}
+
+	// Chunk should now exist.
+	has, err = store.Has(ctx, c.ID)
+	if err != nil {
+		t.Fatalf("Has failed: %v", err)
+	}
+	if !has {
+		t.Error("expected Has to return true after Put")
+	}
+}
+
+func testList(store Store, t *testing.T) {
+	ctx := context.Background()
+
+	// Get the initial count (store may not be empty from previous tests).
+	initialIDs, err := store.List(ctx)
+	if err != nil {
+		t.Fatalf("List failed: %v", err)
+	}
+	initialCount := len(initialIDs)
+
+	// Add some chunks.
+	var expectedIDs []ChunkID
+	for i := 0; i < 5; i++ {
+		data := []byte{byte(i)}
+		c := &Chunk{ID: NewChunkID(data), Data: data}
+		c.Checksum = c.ComputeChecksum()
+		if err := store.Put(ctx, c); err != nil {
+			t.Fatalf("Put failed: %v", err)
+		}
+		expectedIDs = append(expectedIDs, c.ID)
+	}
+
+	// List should return all chunks.
+	ids, err := store.List(ctx)
+	if err != nil {
+		t.Fatalf("List failed: %v", err)
+	}
+	expectedCount := initialCount + len(expectedIDs)
+	if len(ids) != expectedCount {
+		t.Errorf("expected %d IDs, got %d", expectedCount, len(ids))
+	}
+
+	// Verify all expected IDs are present.
+	idMap := make(map[ChunkID]bool)
+	for _, id := range ids {
+		idMap[id] = true
+	}
+	for _, expectedID := range expectedIDs {
+		if !idMap[expectedID] {
+			t.Errorf("expected ID %q not found in list", expectedID)
+		}
+	}
+}
+
+func testChecksumVerification(store Store, t *testing.T) {
+	ctx := context.Background()
+	data := []byte("test data for checksum")
+	chunks := SplitData(data)
+	if len(chunks) != 1 {
+		t.Fatalf("expected 1 chunk, got %d", len(chunks))
+	}
+
+	c := chunks[0]
+	if err := store.Put(ctx, c); err != nil {
+		t.Fatalf("Put failed: %v", err)
+	}
+
+	// Get the chunk and verify checksum.
+	got, err := store.Get(ctx, c.ID)
+	if err != nil {
+		t.Fatalf("Get failed: %v", err)
+	}
+
+	if err := got.VerifyChecksum(); err != nil {
+		t.Errorf("checksum verification failed: %v", err)
+	}
+}
+
+func testLargeChunk(store Store, t *testing.T) {
+	ctx := context.Background()
+
+	// Create a chunk larger than ChunkSize.
+	data := make([]byte, ChunkSize+1024)
+	for i := range data {
+		data[i] = byte(i % 256)
+	}
+
+	c := &Chunk{
+		ID:   NewChunkID(data),
+		Data: data,
+	}
+	c.Checksum = c.ComputeChecksum()
+
+	if err := store.Put(ctx, c); err != nil {
+		t.Fatalf("Put failed: %v", err)
+	}
+
+	got, err := store.Get(ctx, c.ID)
+	if err != nil {
+		t.Fatalf("Get failed: %v", err)
+	}
+
+	if len(got.Data) != len(data) {
+		t.Errorf("data size mismatch: got %d, want %d", len(got.Data), len(data))
+	}
+
+	if err := got.VerifyChecksum(); err != nil {
+		t.Errorf("checksum verification failed: %v", err)
+	}
+}
+
+func testEmptyChunk(store Store, t *testing.T) {
+	ctx := context.Background()
+	data := []byte{}
+
+	c := &Chunk{
+		ID:   NewChunkID(data),
+		Data: data,
+	}
+	c.Checksum = c.ComputeChecksum()
+
+	if err := store.Put(ctx, c); err != nil {
+		t.Fatalf("Put failed: %v", err)
+	}
+
+	got, err := store.Get(ctx, c.ID)
+	if err != nil {
+		t.Fatalf("Get failed: %v", err)
+	}
+
+	if len(got.Data) != 0 {
+		t.Errorf("expected empty data, got %d bytes", len(got.Data))
+	}
+}
+
+func testDuplicatePut(store Store, t *testing.T) {
+	ctx := context.Background()
+	data := []byte("test data for duplicate put")
+	chunks := SplitData(data)
+	if len(chunks) != 1 {
+		t.Fatalf("expected 1 chunk, got %d", len(chunks))
+	}
+
+	c := chunks[0]
+
+	// Put the same chunk twice.
+	if err := store.Put(ctx, c); err != nil {
+		t.Fatalf("first Put failed: %v", err)
+	}
+	if err := store.Put(ctx, c); err != nil {
+		t.Fatalf("second Put failed: %v", err)
+	}
+
+	// Verify the chunk is still accessible.
+	got, err := store.Get(ctx, c.ID)
+	if err != nil {
+		t.Fatalf("Get failed: %v", err)
+	}
+
+	if string(got.Data) != string(c.Data) {
+		t.Errorf("Data mismatch after duplicate Put")
+	}
+}
+
+func testConcurrentOperations(store Store, t *testing.T) {
+	ctx := context.Background()
+	const numGoroutines = 10
+	const numChunksPerGoroutine = 10
+
+	var wg sync.WaitGroup
+	errCh := make(chan error, numGoroutines*numChunksPerGoroutine)
+
+	// Concurrent writes.
+	for i := 0; i < numGoroutines; i++ {
+		wg.Add(1)
+		go func(goroutineID int) {
+			defer wg.Done()
+			for j := 0; j < numChunksPerGoroutine; j++ {
+				data := []byte{byte(goroutineID), byte(j)}
+				c := &Chunk{
+					ID:   NewChunkID(data),
+					Data: data,
+				}
+				c.Checksum = c.ComputeChecksum()
+				if err := store.Put(ctx, c); err != nil {
+					errCh <- err
+				}
+			}
+		}(i)
+	}
+
+	wg.Wait()
+	close(errCh)
+
+	for err := range errCh {
+		t.Errorf("concurrent Put failed: %v", err)
+	}
+}
+
+func testThreadSafety(store Store, t *testing.T) {
+	ctx := context.Background()
+	const numOperations = 100
+	done := make(chan bool)
+
+	// Start multiple goroutines performing various operations.
+	for i := 0; i < 5; i++ {
+		go func(goroutineID int) {
+			for j := 0; j < numOperations; j++ {
+				data := []byte{byte(goroutineID), byte(j)}
+				id := NewChunkID(data)
+
+				switch j % 4 {
+				case 0:
+					c := &Chunk{ID: id, Data: data}
+					c.Checksum = c.ComputeChecksum()
+					store.Put(ctx, c)
+				case 1:
+					store.Get(ctx, id)
+				case 2:
+					store.Has(ctx, id)
+				case 3:
+					store.List(ctx)
+				}
+			}
+			done <- true
+		}(i)
+	}
+
+	// Wait for all goroutines to complete.
+	for i := 0; i < 5; i++ {
+		select {
+		case <-done:
+		case <-time.After(10 * time.Second):
+			t.Fatal("thread safety test timed out")
+		}
+	}
+}

--- a/internal/chunk/memstore.go
+++ b/internal/chunk/memstore.go
@@ -1,0 +1,98 @@
+package chunk
+
+import (
+	"context"
+	"fmt"
+	"sync"
+)
+
+// MemoryStore implements the Store interface in memory.
+// It is primarily useful for testing and development.
+type MemoryStore struct {
+	mu     sync.RWMutex
+	chunks map[ChunkID]*Chunk
+}
+
+// NewMemoryStore creates a new in-memory chunk store.
+func NewMemoryStore() *MemoryStore {
+	return &MemoryStore{
+		chunks: make(map[ChunkID]*Chunk),
+	}
+}
+
+// Put stores a chunk in memory.
+func (s *MemoryStore) Put(_ context.Context, c *Chunk) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	// Store a copy to prevent external mutation.
+	chunkCopy := &Chunk{
+		ID:       c.ID,
+		Data:     make([]byte, len(c.Data)),
+		Checksum: c.Checksum,
+	}
+	copy(chunkCopy.Data, c.Data)
+
+	s.chunks[c.ID] = chunkCopy
+	return nil
+}
+
+// Get retrieves a chunk from memory.
+func (s *MemoryStore) Get(_ context.Context, id ChunkID) (*Chunk, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	c, exists := s.chunks[id]
+	if !exists {
+		return nil, fmt.Errorf("chunk %s not found", id)
+	}
+
+	// Return a copy to prevent external mutation.
+	chunkCopy := &Chunk{
+		ID:       c.ID,
+		Data:     make([]byte, len(c.Data)),
+		Checksum: c.Checksum,
+	}
+	copy(chunkCopy.Data, c.Data)
+
+	return chunkCopy, nil
+}
+
+// Delete removes a chunk from memory.
+func (s *MemoryStore) Delete(_ context.Context, id ChunkID) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	delete(s.chunks, id)
+	return nil
+}
+
+// Has checks if a chunk exists in memory.
+func (s *MemoryStore) Has(_ context.Context, id ChunkID) (bool, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	_, exists := s.chunks[id]
+	return exists, nil
+}
+
+// List returns all chunk IDs in memory.
+func (s *MemoryStore) List(_ context.Context) ([]ChunkID, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	ids := make([]ChunkID, 0, len(s.chunks))
+	for id := range s.chunks {
+		ids = append(ids, id)
+	}
+	return ids, nil
+}
+
+// Close clears all stored chunks.
+// MemoryStore does not hold external resources, so this is a no-op.
+func (s *MemoryStore) Close() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.chunks = make(map[ChunkID]*Chunk)
+	return nil
+}


### PR DESCRIPTION
## Summary

Implement a registry-based factory pattern for pluggable chunk storage backends. This allows new storage backends to be registered and instantiated dynamically without modifying core controller code.

## Changes

- Add `BackendFactory` type for backend creation functions
- Add thread-safe backend registry with `RegisterBackend` function  
- Add `CreateBackend` function to instantiate backends by name
- Add `GetRegisteredBackends` for introspection
- Register built-in "local" and "memory" backends
- Add `MemoryStore` implementation for testing/development
- Add `StoreConformanceTest` for validating Store interface compliance
- Add comprehensive tests for factory and conformance

## Backend Factory API

```go
// Register a backend factory (typically called in init())
RegisterBackend("s3", func(config map[string]string) (Store, error) {
    bucket := config["bucket"]
    return NewS3Store(bucket)
})

// Create a backend instance
store, err := CreateBackend("s3", map[string]string{"bucket": "my-bucket"})
```

## MemoryStore

A new in-memory implementation of the Store interface, useful for:
- Testing and development
- Temporary caching scenarios
- Conformance testing of the Store interface

## Conformance Test Suite

The `StoreConformanceTest` function validates that any backend implementation correctly implements the Store interface. All backends should pass this test suite.

Tests include:
- PutGet, GetNotFound, Delete, Has, List operations
- Checksum verification
- Large chunks, empty chunks
- Duplicate puts
- Concurrent operations
- Thread safety

## Usage Example

```go
// In a backend package's init()
func init() {
    chunk.RegisterBackend("custom", func(config map[string]string) (chunk.Store, error) {
        return NewCustomStore(config["path"])
    })
}
```

Resolves #40