### PR TITLE
[Feature] Add replicas parameter support to CSI CreateVolume

### DIFF
--- a/internal/csi/controller_test.go
+++ b/internal/csi/controller_test.go
@@ -213,6 +213,133 @@ func TestCreateVolumeNoNodes(t *testing.T) {
 	}
 }
 
+// --- Replicas parameter tests ---
+
+func TestCreateVolumeWithReplicas(t *testing.T) {
+	tests := []struct {
+		name           string
+		replicas       string
+		expectedFactor int
+	}{
+		{"default replicas (no parameter)", "", defaultReplicationFactor},
+		{"replicas=2", "2", 2},
+		{"replicas=3", "3", 3},
+		{"replicas=5", "5", 5},
+		{"replicas=1", "1", 1},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cs, store := setupController()
+			req := &csi.CreateVolumeRequest{
+				Name: "test-replicas",
+				CapacityRange: &csi.CapacityRange{
+					RequiredBytes: 4 * 1024 * 1024,
+				},
+				Parameters: map[string]string{},
+			}
+			if tt.replicas != "" {
+				req.Parameters["replicas"] = tt.replicas
+			}
+
+			resp, err := cs.CreateVolume(context.Background(), req)
+			if err != nil {
+				t.Fatalf("CreateVolume failed: %v", err)
+			}
+
+			vm, err := store.GetVolumeMeta(context.Background(), resp.GetVolume().GetVolumeId())
+			if err != nil {
+				t.Fatalf("volume metadata not found: %v", err)
+			}
+
+			if vm.DataProtection == nil {
+				t.Fatal("expected DataProtection to be set")
+			}
+			if vm.DataProtection.Mode != "replication" {
+				t.Errorf("expected mode replication, got %q", vm.DataProtection.Mode)
+			}
+			if vm.DataProtection.ReplicationFactor != tt.expectedFactor {
+				t.Errorf("expected replication factor %d, got %d", tt.expectedFactor, vm.DataProtection.ReplicationFactor)
+			}
+		})
+	}
+}
+
+func TestCreateVolumeInvalidReplicas(t *testing.T) {
+	tests := []struct {
+		name         string
+		replicas     string
+		expectedCode codes.Code
+	}{
+		{"replicas=0", "0", codes.OutOfRange},
+		{"replicas=6", "6", codes.OutOfRange},
+		{"replicas=-1", "-1", codes.OutOfRange},
+		{"replicas=invalid", "invalid", codes.InvalidArgument},
+		{"replicas=abc", "abc", codes.InvalidArgument},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cs, _ := setupController()
+			req := &csi.CreateVolumeRequest{
+				Name: "test-invalid",
+				CapacityRange: &csi.CapacityRange{
+					RequiredBytes: 4 * 1024 * 1024,
+				},
+				Parameters: map[string]string{
+					"replicas": tt.replicas,
+				},
+			}
+
+			_, err := cs.CreateVolume(context.Background(), req)
+			if err == nil {
+				t.Fatal("expected error for invalid replicas value")
+			}
+			if st, ok := status.FromError(err); !ok || st.Code() != tt.expectedCode {
+				t.Errorf("expected %v, got %v", tt.expectedCode, err)
+			}
+		})
+	}
+}
+
+func TestCreateVolumeReplicasOutOfBounds(t *testing.T) {
+	cs, _ := setupController()
+
+	// Test minimum bound (less than 1)
+	_, err := cs.CreateVolume(context.Background(), &csi.CreateVolumeRequest{
+		Name: "test-min",
+		CapacityRange: &csi.CapacityRange{
+			RequiredBytes: 4 * 1024 * 1024,
+		},
+		Parameters: map[string]string{
+			"replicas": "0",
+		},
+	})
+	if err == nil {
+		t.Fatal("expected error for replicas < 1")
+	}
+	if st, ok := status.FromError(err); !ok || st.Code() != codes.OutOfRange {
+		t.Errorf("expected OutOfRange for replicas < 1, got %v", err)
+	}
+
+	// Test maximum bound (greater than 5)
+	_, err = cs.CreateVolume(context.Background(), &csi.CreateVolumeRequest{
+		Name: "test-max",
+		CapacityRange: &csi.CapacityRange{
+			RequiredBytes: 4 * 1024 * 1024,
+		},
+		Parameters: map[string]string{
+			"replicas": "6",
+		},
+	})
+	if err == nil {
+		t.Fatal("expected error for replicas > 5")
+	}
+	if st, ok := status.FromError(err); !ok || st.Code() != codes.OutOfRange {
+		t.Errorf("expected OutOfRange for replicas > 5, got %v", err)
+	}
+}
+
 // --- DeleteVolume tests ---
 
 func TestDeleteVolume(t *testing.T) {

--- a/internal/metadata/store.go
+++ b/internal/metadata/store.go
@@ -16,11 +16,15 @@ import (
 	"github.com/piwi3910/novastor/internal/metrics"
 )
 
+// VolumeMeta stores metadata about a provisioned volume.
 type VolumeMeta struct {
 	VolumeID  string   `json:"volumeID"`
 	Pool      string   `json:"pool"`
 	SizeBytes uint64   `json:"sizeBytes"`
 	ChunkIDs  []string `json:"chunkIDs"`
+
+	// DataProtection stores the replication factor for this volume.
+	DataProtection *DataProtection `json:"dataProtection,omitempty"`
 
 	// NVMe-oF target fields populated by the CSI controller after target creation.
 	TargetNodeID  string `json:"targetNodeID,omitempty"`
@@ -33,6 +37,15 @@ type VolumeMeta struct {
 
 	// ComplianceInfo tracks the current compliance state of this volume.
 	ComplianceInfo *ComplianceInfo `json:"complianceInfo,omitempty"`
+}
+
+// DataProtection describes how data is protected for a volume.
+type DataProtection struct {
+	// Mode is the protection mode: "replication" or "erasureCoding".
+	Mode string `json:"mode"`
+
+	// ReplicationFactor is the number of replicas (1-5).
+	ReplicationFactor int `json:"replicationFactor,omitempty"`
 }
 
 type PlacementMap struct {


### PR DESCRIPTION
## Summary
Wire the `replicas` StorageClass parameter into the CSI CreateVolume path
to honor the requested replication factor for volume provisioning.

## Changes

### Metadata Store (`internal/metadata/store.go`)
- Added `DataProtection` field to `VolumeMeta` struct
- Created `DataProtection` struct with `Mode` and `ReplicationFactor` fields

### CSI Controller (`internal/csi/controller.go`)
- Added constants: `defaultReplicationFactor` (3), `minReplicationFactor` (1), `maxReplicationFactor` (5)
- Added `parseReplicationFactor()` helper function to parse and validate the replicas parameter
- Updated `CreateVolume()` to parse replicas from StorageClass parameters
- Stores replication factor in `VolumeMeta.DataProtection`

### Tests (`internal/csi/controller_test.go`)
- Added `TestCreateVolumeWithReplicas` - tests valid values (1-5) and default behavior
- Added `TestCreateVolumeInvalidReplicas` - tests error handling for invalid inputs
- Added `TestCreateVolumeReplicasOutOfBounds` - tests boundary conditions

## Test Plan
- [x] Unit tests for parameter parsing (valid values)
- [x] Unit tests for invalid values (non-integer, out of range)
- [x] Unit tests for default behavior (no parameter)
- [x] All existing tests still pass

## Test Results
```
ok  	github.com/piwi3910/novastor/internal/csi	0.455s
ok  	github.com/piwi3910/novastor/internal/metadata	34.125s
```

Resolves #16