### PR TITLE
[Feature] Implement distributed NFS lock coordination

### DIFF
--- a/internal/filer/distributed_lock.go
+++ b/internal/filer/distributed_lock.go
@@ -1,0 +1,341 @@
+package filer
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/piwi3910/novastor/internal/metadata"
+	"github.com/piwi3910/novastor/internal/metrics"
+)
+
+// DefaultLeaseTTL is the default TTL for lock leases.
+// Clients should renew before this expires.
+const DefaultLeaseTTL = 30 * time.Second
+
+// RenewalInterval is how often we attempt to renew locks we hold.
+const RenewalInterval = 10 * time.Second
+
+// RenewalTimeout is how long we wait for a renewal to succeed.
+const RenewalTimeout = 5 * time.Second
+
+// DistributedLockManager manages distributed file locks using the metadata service.
+// It implements lease-based locking with automatic renewal and expiration handling.
+type DistributedLockManager struct {
+	// client is the metadata service client for distributed lock operations.
+	client metadata.LockClient
+	// filerID uniquely identifies this filer instance.
+	filerID string
+	// localLeases tracks locks held by this filer instance for renewal.
+	localLeases map[string]*localLease
+	// mu protects localLeases.
+	mu sync.RWMutex
+	// done is closed to stop the renewal goroutine.
+	done chan struct{}
+	// wg waits for the renewal goroutine to exit.
+	wg sync.WaitGroup
+}
+
+// localLease represents a lease held by this filer instance.
+type localLease struct {
+	lease     *metadata.LockLease
+	renewAt   time.Time
+	stopRenew chan struct{}
+}
+
+// NewDistributedLockManager creates a new distributed lock manager.
+func NewDistributedLockManager(client metadata.LockClient, filerID string) *DistributedLockManager {
+	lm := &DistributedLockManager{
+		client:      client,
+		filerID:     filerID,
+		localLeases: make(map[string]*localLease),
+		done:        make(chan struct{}),
+	}
+	lm.startRenewalGoroutine()
+	return lm
+}
+
+// startRenewalGoroutine starts a background goroutine that renews leases.
+func (lm *DistributedLockManager) startRenewalGoroutine() {
+	lm.wg.Add(1)
+	go func() {
+		defer lm.wg.Done()
+		ticker := time.NewTicker(RenewalInterval)
+		defer ticker.Stop()
+
+		for {
+			select {
+			case <-lm.done:
+				return
+			case <-ticker.C:
+				lm.renewLeases()
+			}
+		}
+	}()
+}
+
+// renewLeases renews all local leases that are due for renewal.
+func (lm *DistributedLockManager) renewLeases() {
+	lm.mu.Lock()
+	defer lm.mu.Unlock()
+
+	now := time.Now()
+
+	for leaseID, local := range lm.localLeases {
+		if now.Before(local.renewAt) {
+			continue
+		}
+
+		ctx, cancel := context.WithTimeout(context.Background(), RenewalTimeout)
+		args := &metadata.RenewLockArgs{
+			LeaseID: leaseID,
+			TTL:     DefaultLeaseTTL,
+		}
+		lease, err := lm.client.RenewLock(ctx, args)
+		cancel()
+
+		if err != nil {
+			// Renewal failed - remove from local tracking.
+			delete(lm.localLeases, leaseID)
+			metrics.LockRenewalFailures.Inc()
+			metrics.LockOperationsTotal.WithLabelValues("renew", "failure").Inc()
+			// The lease will eventually expire in the metadata service.
+			continue
+		}
+
+		// Update local lease info.
+		local.lease = lease
+		local.renewAt = time.Now().Add(RenewalInterval)
+		metrics.LockOperationsTotal.WithLabelValues("renew", "success").Inc()
+	}
+
+	metrics.DistributedLockLeases.Set(float64(len(lm.localLeases)))
+}
+
+// Lock attempts to acquire a distributed file lock.
+// The lock will be automatically renewed until explicitly released.
+func (lm *DistributedLockManager) Lock(owner string, ino uint64, start, end int64, lockType LockType) error {
+	return lm.LockWithVolume(owner, "", ino, start, end, lockType)
+}
+
+// LockWithVolume attempts to acquire a distributed file lock with a volume ID.
+func (lm *DistributedLockManager) LockWithVolume(owner, volumeID string, ino uint64, start, end int64, lockType LockType) error {
+	// Convert lock type.
+	var metaType metadata.LockType
+	switch lockType {
+	case LockRead:
+		metaType = metadata.LockRead
+	case LockWrite:
+		metaType = metadata.LockWrite
+	default:
+		return fmt.Errorf("invalid lock type: %d", lockType)
+	}
+
+	ctx := context.Background()
+	args := &metadata.AcquireLockArgs{
+		Owner:    owner,
+		VolumeID: volumeID,
+		Ino:      ino,
+		Start:    start,
+		End:      end,
+		Type:     metaType,
+		TTL:      DefaultLeaseTTL,
+		FilerID:  lm.filerID,
+	}
+
+	result, err := lm.client.AcquireLock(ctx, args)
+	if err != nil {
+		metrics.LockOperationsTotal.WithLabelValues("acquire", "failure").Inc()
+		return fmt.Errorf("acquiring lock: %w", err)
+	}
+
+	metrics.LockOperationsTotal.WithLabelValues("acquire", "success").Inc()
+
+	// Track locally for renewal.
+	lm.mu.Lock()
+	defer lm.mu.Unlock()
+
+	lm.localLeases[result.LeaseID] = &localLease{
+		lease: &metadata.LockLease{
+			LeaseID:   result.LeaseID,
+			Owner:     owner,
+			VolumeID:  volumeID,
+			Ino:       ino,
+			Start:     start,
+			End:       end,
+			Type:      metaType,
+			ExpiresAt: result.ExpiresAt,
+			FilerID:   lm.filerID,
+		},
+		renewAt: time.Now().Add(RenewalInterval),
+	}
+	metrics.DistributedLockLeases.Set(float64(len(lm.localLeases)))
+
+	return nil
+}
+
+// Unlock releases a distributed file lock.
+// The lease ID identifies which lock to release.
+func (lm *DistributedLockManager) Unlock(leaseID string) error {
+	return lm.UnlockWithOwner(leaseID, "")
+}
+
+// UnlockWithOwner releases a lock, verifying the owner if provided.
+func (lm *DistributedLockManager) UnlockWithOwner(leaseID, owner string) error {
+	ctx := context.Background()
+	args := &metadata.ReleaseLockArgs{
+		LeaseID: leaseID,
+		Owner:   owner,
+	}
+
+	if err := lm.client.ReleaseLock(ctx, args); err != nil {
+		metrics.LockOperationsTotal.WithLabelValues("release", "failure").Inc()
+		return fmt.Errorf("releasing lock: %w", err)
+	}
+
+	// Remove from local tracking.
+	lm.mu.Lock()
+	delete(lm.localLeases, leaseID)
+	metrics.DistributedLockLeases.Set(float64(len(lm.localLeases)))
+	lm.mu.Unlock()
+
+	metrics.LockOperationsTotal.WithLabelValues("release", "success").Inc()
+	return nil
+}
+
+// TestLock checks if a lock could be acquired without actually acquiring it.
+// Returns nil if no conflict exists, or the conflicting lock info.
+func (lm *DistributedLockManager) TestLock(volumeID string, ino uint64, start, end int64, lockType LockType) (*metadata.LockLease, error) {
+	var metaType metadata.LockType
+	switch lockType {
+	case LockRead:
+		metaType = metadata.LockRead
+	case LockWrite:
+		metaType = metadata.LockWrite
+	default:
+		return nil, fmt.Errorf("invalid lock type: %d", lockType)
+	}
+
+	ctx := context.Background()
+	args := &metadata.TestLockArgs{
+		VolumeID: volumeID,
+		Ino:      ino,
+		Start:    start,
+		End:      end,
+		Type:     metaType,
+	}
+
+	return lm.client.TestLock(ctx, args)
+}
+
+// ReleaseAllForOwner releases all locks held by a specific owner.
+// This is typically called when an NFS client disconnects.
+func (lm *DistributedLockManager) ReleaseAllForOwner(owner string) error {
+	ctx := context.Background()
+	volumeID := "" // Release across all volumes.
+
+	// List all locks to find ones owned by this client.
+	locks, err := lm.client.ListLocks(ctx, volumeID)
+	if err != nil {
+		return fmt.Errorf("listing locks: %w", err)
+	}
+
+	var releaseErrors []error
+	for _, lock := range locks {
+		if lock.Owner == owner {
+			args := &metadata.ReleaseLockArgs{
+				LeaseID: lock.LeaseID,
+				Owner:   owner,
+			}
+			if err := lm.client.ReleaseLock(ctx, args); err != nil {
+				releaseErrors = append(releaseErrors, err)
+			}
+
+			// Remove from local tracking if we held it.
+			lm.mu.Lock()
+			delete(lm.localLeases, lock.LeaseID)
+			lm.mu.Unlock()
+		}
+	}
+
+	metrics.DistributedLockLeases.Set(float64(len(lm.localLeases)))
+
+	if len(releaseErrors) > 0 {
+		return fmt.Errorf("errors releasing %d locks: %v", len(releaseErrors), releaseErrors)
+	}
+	return nil
+}
+
+// Close stops the lock manager and releases all locally held locks.
+func (lm *DistributedLockManager) Close() error {
+	close(lm.done)
+	lm.wg.Wait()
+
+	// Release all local locks.
+	lm.mu.Lock()
+	defer lm.mu.Unlock()
+
+	ctx := context.Background()
+	var releaseErrors []error
+
+	for leaseID, local := range lm.localLeases {
+		args := &metadata.ReleaseLockArgs{
+			LeaseID: leaseID,
+			Owner:   local.lease.Owner,
+		}
+		if err := lm.client.ReleaseLock(ctx, args); err != nil {
+			releaseErrors = append(releaseErrors, err)
+		}
+	}
+
+	lm.localLeases = make(map[string]*localLease)
+	metrics.DistributedLockLeases.Set(0)
+
+	if len(releaseErrors) > 0 {
+		return fmt.Errorf("errors releasing locks during close: %v", releaseErrors)
+	}
+	return nil
+}
+
+// GetLocalLeaseCount returns the number of leases currently held by this filer.
+func (lm *DistributedLockManager) GetLocalLeaseCount() int {
+	lm.mu.RLock()
+	defer lm.mu.RUnlock()
+	return len(lm.localLeases)
+}
+
+// RunCleanup runs a one-time cleanup of expired locks.
+// This should be called periodically by one filer instance (e.g., the leader).
+func (lm *DistributedLockManager) RunCleanup(ctx context.Context) (int, error) {
+	count, err := lm.client.CleanupExpiredLocks(ctx)
+	if err != nil {
+		return 0, fmt.Errorf("cleaning expired locks: %w", err)
+	}
+	if count > 0 {
+		metrics.LockLeaseExpirations.Add(float64(count))
+	}
+	return count, nil
+}
+
+// StartCleanupPeriodic starts a background goroutine that periodically cleans up expired locks.
+// Only one filer instance should run this (e.g., the leader).
+func (lm *DistributedLockManager) StartCleanupPeriodic(ctx context.Context, interval time.Duration) {
+	lm.wg.Add(1)
+	go func() {
+		defer lm.wg.Done()
+		ticker := time.NewTicker(interval)
+		defer ticker.Stop()
+
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-lm.done:
+				return
+			case <-ticker.C:
+				_, _ = lm.RunCleanup(ctx)
+			}
+		}
+	}()
+}

--- a/internal/filer/distributed_lock_test.go
+++ b/internal/filer/distributed_lock_test.go
@@ -1,0 +1,487 @@
+package filer
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/piwi3910/novastor/internal/metadata"
+)
+
+// Helper to call metadata.conflicts with proper types.
+func checkConflicts(a, b *metadata.LockLease) bool {
+	// This is a local implementation that mirrors metadata.conflicts
+	// for use in the mock client.
+	if a.Owner == b.Owner {
+		return false
+	}
+	if a.IsExpired() || b.IsExpired() {
+		return false
+	}
+	if !overlaps(a.Start, a.End, b.Start, b.End) {
+		return false
+	}
+	if a.Type == metadata.LockRead && b.Type == metadata.LockRead {
+		return false
+	}
+	return true
+}
+
+// mockLockClient is a mock implementation of metadata.LockClient for testing.
+type mockLockClient struct {
+	mu            sync.Mutex
+	leases        map[string]*metadata.LockLease
+	leaseCounter  int
+	failRenew     bool
+	failAcquire   bool
+	cleanupCalled bool
+}
+
+func newMockLockClient() *mockLockClient {
+	return &mockLockClient{
+		leases: make(map[string]*metadata.LockLease),
+	}
+}
+
+func (m *mockLockClient) AcquireLock(_ context.Context, args *metadata.AcquireLockArgs) (*metadata.AcquireLockResult, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if m.failAcquire {
+		return nil, fmt.Errorf("acquire failed")
+	}
+
+	// Check for conflicts with existing locks.
+	for _, lease := range m.leases {
+		if lease.IsExpired() {
+			continue
+		}
+		candidate := &metadata.LockLease{
+			Owner:     args.Owner,
+			Ino:       args.Ino,
+			Start:     args.Start,
+			End:       args.End,
+			Type:      args.Type,
+			ExpiresAt: time.Now().Add(args.TTL).UnixNano(),
+		}
+		if lease.Ino == args.Ino && checkConflicts(candidate, lease) {
+			return &metadata.AcquireLockResult{
+				ConflictingOwner: lease.Owner,
+			}, fmt.Errorf("lock conflict")
+		}
+	}
+
+	// Create new lease.
+	leaseID := fmt.Sprintf("lease-%d", m.leaseCounter)
+	m.leaseCounter++
+
+	lease := &metadata.LockLease{
+		LeaseID:   leaseID,
+		Owner:     args.Owner,
+		VolumeID:  args.VolumeID,
+		Ino:       args.Ino,
+		Start:     args.Start,
+		End:       args.End,
+		Type:      args.Type,
+		ExpiresAt: time.Now().Add(args.TTL).UnixNano(),
+		FilerID:   args.FilerID,
+	}
+	m.leases[leaseID] = lease
+
+	return &metadata.AcquireLockResult{
+		LeaseID:   leaseID,
+		ExpiresAt: lease.ExpiresAt,
+	}, nil
+}
+
+func (m *mockLockClient) RenewLock(_ context.Context, args *metadata.RenewLockArgs) (*metadata.LockLease, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if m.failRenew {
+		return nil, fmt.Errorf("renew failed")
+	}
+
+	lease, ok := m.leases[args.LeaseID]
+	if !ok {
+		return nil, fmt.Errorf("lease not found")
+	}
+
+	lease.ExpiresAt = time.Now().Add(args.TTL).UnixNano()
+	return lease, nil
+}
+
+func (m *mockLockClient) ReleaseLock(_ context.Context, args *metadata.ReleaseLockArgs) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	lease, ok := m.leases[args.LeaseID]
+	if !ok {
+		return fmt.Errorf("lease not found")
+	}
+
+	if args.Owner != "" && lease.Owner != args.Owner {
+		return fmt.Errorf("owner mismatch")
+	}
+
+	delete(m.leases, args.LeaseID)
+	return nil
+}
+
+func (m *mockLockClient) TestLock(_ context.Context, args *metadata.TestLockArgs) (*metadata.LockLease, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	for _, lease := range m.leases {
+		if lease.IsExpired() {
+			continue
+		}
+		if lease.Ino != args.Ino {
+			continue
+		}
+		candidate := &metadata.LockLease{
+			Ino:       args.Ino,
+			Start:     args.Start,
+			End:       args.End,
+			Type:      args.Type,
+			ExpiresAt: time.Now().Add(time.Minute).UnixNano(), // Set far future so it's not expired
+		}
+		if checkConflicts(candidate, lease) {
+			return lease, nil
+		}
+	}
+	return nil, nil
+}
+
+func (m *mockLockClient) GetLock(_ context.Context, leaseID string) (*metadata.LockLease, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	lease, ok := m.leases[leaseID]
+	if !ok {
+		return nil, fmt.Errorf("lease not found")
+	}
+	return lease, nil
+}
+
+func (m *mockLockClient) ListLocks(_ context.Context, volumeID string) ([]*metadata.LockLease, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	var result []*metadata.LockLease
+	for _, lease := range m.leases {
+		if lease.IsExpired() {
+			continue
+		}
+		if volumeID != "" && lease.VolumeID != volumeID {
+			continue
+		}
+		result = append(result, lease)
+	}
+	return result, nil
+}
+
+func (m *mockLockClient) CleanupExpiredLocks(_ context.Context) (int, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	m.cleanupCalled = true
+	cleaned := 0
+	now := time.Now().UnixNano()
+
+	for leaseID, lease := range m.leases {
+		if lease.ExpiresAt < now {
+			delete(m.leases, leaseID)
+			cleaned++
+		}
+	}
+	return cleaned, nil
+}
+
+// TestDistributedLockManager_Acquire tests acquiring locks.
+func TestDistributedLockManager_Acquire(t *testing.T) {
+	client := newMockLockClient()
+	lm := NewDistributedLockManager(client, "filer1")
+	defer mustClose(lm)
+
+	err := lm.Lock("client1", 1, 0, 100, LockWrite)
+	if err != nil {
+		t.Fatalf("failed to acquire lock: %v", err)
+	}
+
+	if lm.GetLocalLeaseCount() != 1 {
+		t.Errorf("expected 1 local lease, got %d", lm.GetLocalLeaseCount())
+	}
+
+	// Verify the lease exists in the mock.
+	leases, _ := client.ListLocks(context.Background(), "")
+	if len(leases) != 1 {
+		t.Errorf("expected 1 lease in client, got %d", len(leases))
+	}
+}
+
+// TestDistributedLockManager_Conflict tests that conflicting locks are rejected.
+func TestDistributedLockManager_Conflict(t *testing.T) {
+	client := newMockLockClient()
+	lm := NewDistributedLockManager(client, "filer1")
+	defer mustClose(lm)
+
+	// Acquire first lock.
+	if err := lm.Lock("client1", 1, 0, 100, LockWrite); err != nil {
+		t.Fatalf("failed to acquire first lock: %v", err)
+	}
+
+	// Try to acquire conflicting lock.
+	err := lm.Lock("client2", 1, 50, 150, LockWrite)
+	if err == nil {
+		t.Fatal("expected conflict error, got nil")
+	}
+}
+
+// TestDistributedLockManager_ReadWriteShared tests that read locks are shared.
+func TestDistributedLockManager_ReadWriteShared(t *testing.T) {
+	client := newMockLockClient()
+	lm := NewDistributedLockManager(client, "filer1")
+	defer mustClose(lm)
+
+	// Create two lock managers for different "filers".
+	lm2 := NewDistributedLockManager(client, "filer2")
+	defer mustClose(lm2)
+
+	// Acquire read lock from first manager.
+	if err := lm.Lock("client1", 1, 0, 100, LockRead); err != nil {
+		t.Fatalf("failed to acquire first read lock: %v", err)
+	}
+
+	// Acquire read lock from second manager (simulating different filer).
+	if err := lm2.Lock("client2", 1, 0, 100, LockRead); err != nil {
+		t.Fatalf("failed to acquire second read lock: %v", err)
+	}
+
+	leases, _ := client.ListLocks(context.Background(), "")
+	if len(leases) != 2 {
+		t.Errorf("expected 2 leases, got %d", len(leases))
+	}
+}
+
+// TestDistributedLockManager_Unlock tests releasing locks.
+func TestDistributedLockManager_Unlock(t *testing.T) {
+	client := newMockLockClient()
+	lm := NewDistributedLockManager(client, "filer1")
+	defer mustClose(lm)
+
+	// Need to get the lease ID somehow. For this test, we'll
+	// use the mock directly to find it.
+	_, _ = client.AcquireLock(context.Background(), &metadata.AcquireLockArgs{
+		Owner:   "client1",
+		Ino:     1,
+		Start:   0,
+		End:     100,
+		Type:    metadata.LockWrite,
+		TTL:     time.Minute,
+		FilerID: "filer1",
+	})
+
+	leases, _ := client.ListLocks(context.Background(), "")
+	if len(leases) != 1 {
+		t.Fatalf("expected 1 lease, got %d", len(leases))
+	}
+	leaseID := leases[0].LeaseID
+
+	// Unlock using the lease ID.
+	if err := lm.Unlock(leaseID); err != nil {
+		t.Fatalf("failed to unlock: %v", err)
+	}
+
+	leases, _ = client.ListLocks(context.Background(), "")
+	if len(leases) != 0 {
+		t.Errorf("expected 0 leases after unlock, got %d", len(leases))
+	}
+}
+
+// TestDistributedLockManager_TestLock tests the TestLock method.
+func TestDistributedLockManager_TestLock(t *testing.T) {
+	client := newMockLockClient()
+	lm := NewDistributedLockManager(client, "filer1")
+	defer mustClose(lm)
+
+	// Acquire a lock.
+	if err := lm.Lock("client1", 1, 0, 100, LockWrite); err != nil {
+		t.Fatalf("failed to acquire lock: %v", err)
+	}
+
+	// Test for conflict.
+	conflict, err := lm.TestLock("", 1, 50, 150, LockWrite)
+	if err != nil {
+		t.Fatalf("TestLock failed: %v", err)
+	}
+	if conflict == nil {
+		t.Fatal("expected conflict, got nil")
+	}
+
+	// Test no conflict.
+	conflict, err = lm.TestLock("", 1, 200, 300, LockWrite)
+	if err != nil {
+		t.Fatalf("TestLock failed: %v", err)
+	}
+	if conflict != nil {
+		t.Errorf("expected no conflict, got %v", conflict)
+	}
+}
+
+// TestDistributedLockManager_ReleaseAllForOwner tests releasing all locks for an owner.
+func TestDistributedLockManager_ReleaseAllForOwner(t *testing.T) {
+	client := newMockLockClient()
+	lm := NewDistributedLockManager(client, "filer1")
+	defer mustClose(lm)
+
+	// Acquire multiple locks for the same owner.
+	if err := lm.Lock("client1", 1, 0, 100, LockWrite); err != nil {
+		t.Fatalf("failed to acquire first lock: %v", err)
+	}
+	if err := lm.Lock("client1", 2, 0, 100, LockWrite); err != nil {
+		t.Fatalf("failed to acquire second lock: %v", err)
+	}
+
+	// Release all for owner.
+	if err := lm.ReleaseAllForOwner("client1"); err != nil {
+		t.Fatalf("failed to release all: %v", err)
+	}
+
+	leases, _ := client.ListLocks(context.Background(), "")
+	if len(leases) != 0 {
+		t.Errorf("expected 0 leases after release all, got %d", len(leases))
+	}
+}
+
+// TestDistributedLockManager_Cleanup tests the cleanup functionality.
+func TestDistributedLockManager_Cleanup(t *testing.T) {
+	client := newMockLockClient()
+	lm := NewDistributedLockManager(client, "filer1")
+	defer mustClose(lm)
+
+	ctx := context.Background()
+
+	// Add an expired lease directly to the mock.
+	expiredLease := &metadata.LockLease{
+		LeaseID:   "expired-lease",
+		Owner:     "client1",
+		Ino:       1,
+		Start:     0,
+		End:       100,
+		Type:      metadata.LockWrite,
+		ExpiresAt: time.Now().Add(-time.Hour).UnixNano(),
+	}
+	client.mu.Lock()
+	client.leases["expired-lease"] = expiredLease
+	client.mu.Unlock()
+
+	// Run cleanup.
+	count, err := lm.RunCleanup(ctx)
+	if err != nil {
+		t.Fatalf("cleanup failed: %v", err)
+	}
+
+	if count != 1 {
+		t.Errorf("expected to clean 1 lock, got %d", count)
+	}
+}
+
+// TestDistributedLockManager_ConcurrentAcquire tests concurrent lock acquisition.
+func TestDistributedLockManager_ConcurrentAcquire(t *testing.T) {
+	client := newMockLockClient()
+	lm := NewDistributedLockManager(client, "filer1")
+	defer mustClose(lm)
+
+	var wg sync.WaitGroup
+	errors := make(chan error, 10)
+	successes := 0
+
+	// Try to acquire the same lock from multiple "clients".
+	for i := 0; i < 10; i++ {
+		wg.Add(1)
+		go func(clientID int) {
+			defer wg.Done()
+			owner := fmt.Sprintf("client%d", clientID)
+			err := lm.Lock(owner, 1, 0, 100, LockWrite)
+			if err == nil {
+				successes++
+			} else {
+				errors <- err
+			}
+		}(i)
+	}
+
+	wg.Wait()
+	close(errors)
+
+	// Only one should succeed.
+	if successes != 1 {
+		t.Errorf("expected 1 successful lock, got %d", successes)
+	}
+
+	// Collect conflicts.
+	conflictCount := 0
+	for err := range errors {
+		if err != nil {
+			conflictCount++
+		}
+	}
+	if conflictCount != 9 {
+		t.Errorf("expected 9 conflicts, got %d", conflictCount)
+	}
+}
+
+// TestDistributedLockManager_Close tests that Close releases all locks.
+func TestDistributedLockManager_Close(t *testing.T) {
+	client := newMockLockClient()
+	lm := NewDistributedLockManager(client, "filer1")
+
+	// Acquire some locks.
+	if err := lm.Lock("client1", 1, 0, 100, LockWrite); err != nil {
+		t.Fatalf("failed to acquire first lock: %v", err)
+	}
+	if err := lm.Lock("client1", 2, 0, 100, LockWrite); err != nil {
+		t.Fatalf("failed to acquire second lock: %v", err)
+	}
+
+	// Close the manager.
+	if err := lm.Close(); err != nil {
+		t.Fatalf("close failed: %v", err)
+	}
+
+	// Verify all locks were released.
+	leases, _ := client.ListLocks(context.Background(), "")
+	if len(leases) != 0 {
+		t.Errorf("expected 0 leases after close, got %d", len(leases))
+	}
+}
+
+// TestDistributedLockManager_SameOwnerNoConflict tests that same owner doesn't conflict.
+func TestDistributedLockManager_SameOwnerNoConflict(t *testing.T) {
+	client := newMockLockClient()
+	lm := NewDistributedLockManager(client, "filer1")
+	defer mustClose(lm)
+
+	// Acquire first lock.
+	if err := lm.Lock("client1", 1, 0, 100, LockWrite); err != nil {
+		t.Fatalf("failed to acquire first lock: %v", err)
+	}
+
+	// Acquire overlapping lock from same owner.
+	if err := lm.Lock("client1", 1, 50, 150, LockWrite); err != nil {
+		t.Errorf("same owner should not conflict: %v", err)
+	}
+
+	if lm.GetLocalLeaseCount() != 2 {
+		t.Errorf("expected 2 local leases, got %d", lm.GetLocalLeaseCount())
+	}
+}
+
+// mustClose is a helper that closes a resource and ignores any error.
+// Used in tests to avoid unchecked error violations from defer.
+func mustClose(c interface{ Close() error }) {
+	_ = c.Close()
+}

--- a/internal/metadata/fsm.go
+++ b/internal/metadata/fsm.go
@@ -16,16 +16,17 @@ const (
 	opPut    = "put"
 	opDelete = "delete"
 
-	bucketVolumes         = "volumes"
-	bucketPlacements      = "placements"
-	bucketObjects         = "objects"
-	bucketBuckets         = "buckets" // S3 buckets, not FSM buckets
-	bucketMultipart       = "multipart"
-	bucketSnapshots       = "snapshots"
-	bucketShardPlacements = "shardPlacements"
-	bucketVolumeCompliance = "volumeCompliance"
-	bucketHealTasks       = "healTasks"
-	bucketChunkHealLocks  = "chunkHealLocks"
+	bucketVolumes           = "volumes"
+	bucketPlacements        = "placements"
+	bucketObjects           = "objects"
+	bucketBuckets           = "buckets" // S3 buckets, not FSM buckets
+	bucketMultipart         = "multipart"
+	bucketSnapshots         = "snapshots"
+	bucketShardPlacements   = "shardPlacements"
+	bucketVolumeCompliance  = "volumeCompliance"
+	bucketHealTasks         = "healTasks"
+	bucketChunkHealLocks    = "chunkHealLocks"
+	bucketLocks             = "locks" // File lock leases
 )
 
 // MetadataFSM defines the interface that both the in-memory FSM and the
@@ -59,19 +60,20 @@ var _ MetadataFSM = (*FSM)(nil)
 func NewFSM() *FSM {
 	return &FSM{
 		buckets: map[string]map[string][]byte{
-			bucketVolumes:          {},
-			bucketPlacements:       {},
-			bucketObjects:          {},
-			bucketBuckets:          {},
-			bucketMultipart:        {},
-			bucketSnapshots:        {},
-			bucketShardPlacements:  {},
-			bucketVolumeCompliance: {},
-			bucketHealTasks:        {},
-			bucketChunkHealLocks:   {},
-			"nodes":                {},
-			"inodes":               {},
-			"dirents":              {},
+			bucketVolumes:           {},
+			bucketPlacements:        {},
+			bucketObjects:           {},
+			bucketBuckets:           {},
+			bucketMultipart:         {},
+			bucketSnapshots:         {},
+			bucketShardPlacements:   {},
+			bucketVolumeCompliance:  {},
+			bucketHealTasks:         {},
+			bucketChunkHealLocks:    {},
+			bucketLocks:             {},
+			"nodes":                 {},
+			"inodes":                {},
+			"dirents":               {},
 		},
 	}
 }

--- a/internal/metadata/grpc_client.go
+++ b/internal/metadata/grpc_client.go
@@ -471,3 +471,99 @@ func (c *GRPCClient) ListNodeMetas(ctx context.Context) ([]*NodeMeta, error) {
 	}
 	return metas, nil
 }
+
+// ---- Lock lease operations ----
+
+// AcquireLock attempts to acquire a distributed file lock lease.
+func (c *GRPCClient) AcquireLock(ctx context.Context, args *AcquireLockArgs) (*AcquireLockResult, error) {
+	data, err := c.exec(ctx, "AcquireLock", args)
+	if err != nil {
+		return nil, err
+	}
+	var result AcquireLockResult
+	if err := json.Unmarshal(data, &result); err != nil {
+		return nil, fmt.Errorf("unmarshaling AcquireLockResult: %w", err)
+	}
+	return &result, nil
+}
+
+// RenewLock extends the expiration time of an existing lock lease.
+func (c *GRPCClient) RenewLock(ctx context.Context, args *RenewLockArgs) (*LockLease, error) {
+	data, err := c.exec(ctx, "RenewLock", args)
+	if err != nil {
+		return nil, err
+	}
+	var lease LockLease
+	if err := json.Unmarshal(data, &lease); err != nil {
+		return nil, fmt.Errorf("unmarshaling LockLease: %w", err)
+	}
+	return &lease, nil
+}
+
+// ReleaseLock releases a lock lease.
+func (c *GRPCClient) ReleaseLock(ctx context.Context, args *ReleaseLockArgs) error {
+	_, err := c.exec(ctx, "ReleaseLock", args)
+	return err
+}
+
+// TestLock checks if a lock could be acquired without actually acquiring it.
+func (c *GRPCClient) TestLock(ctx context.Context, args *TestLockArgs) (*LockLease, error) {
+	data, err := c.exec(ctx, "TestLock", args)
+	if err != nil {
+		return nil, err
+	}
+	if len(data) == 0 {
+		return nil, nil
+	}
+	var lease LockLease
+	if err := json.Unmarshal(data, &lease); err != nil {
+		return nil, fmt.Errorf("unmarshaling LockLease: %w", err)
+	}
+	return &lease, nil
+}
+
+// GetLock retrieves a lock lease by ID.
+func (c *GRPCClient) GetLock(ctx context.Context, leaseID string) (*LockLease, error) {
+	data, err := c.exec(ctx, "GetLock", struct {
+		LeaseID string `json:"leaseID"`
+	}{LeaseID: leaseID})
+	if err != nil {
+		return nil, err
+	}
+	var lease LockLease
+	if err := json.Unmarshal(data, &lease); err != nil {
+		return nil, fmt.Errorf("unmarshaling LockLease: %w", err)
+	}
+	return &lease, nil
+}
+
+// ListLocks returns all active lock leases, optionally filtered by volume ID.
+func (c *GRPCClient) ListLocks(ctx context.Context, volumeID string) ([]*LockLease, error) {
+	data, err := c.exec(ctx, "ListLocks", struct {
+		VolumeID string `json:"volumeID,omitempty"`
+	}{VolumeID: volumeID})
+	if err != nil {
+		return nil, err
+	}
+	var locks []*LockLease
+	if err := json.Unmarshal(data, &locks); err != nil {
+		return nil, fmt.Errorf("unmarshaling []*LockLease: %w", err)
+	}
+	return locks, nil
+}
+
+// CleanupExpiredLocks removes expired lock leases.
+func (c *GRPCClient) CleanupExpiredLocks(ctx context.Context) (int, error) {
+	data, err := c.exec(ctx, "CleanupExpiredLocks", nil)
+	if err != nil {
+		return 0, err
+	}
+	var result struct {
+		Cleaned int `json:"cleaned"`
+	}
+	if err := json.Unmarshal(data, &result); err != nil {
+		return 0, fmt.Errorf("unmarshaling cleanup result: %w", err)
+	}
+	return result.Cleaned, nil
+}
+

--- a/internal/metadata/grpc_server.go
+++ b/internal/metadata/grpc_server.go
@@ -122,6 +122,22 @@ func (s *GRPCServer) Execute(ctx context.Context, req *pb.MetadataRequest) (*pb.
 	case "ListNodeMetas":
 		return s.listNodeMetas(ctx)
 
+	// ---- Lock operations ----
+	case "AcquireLock":
+		return s.acquireLock(ctx, req.Payload)
+	case "RenewLock":
+		return s.renewLock(ctx, req.Payload)
+	case "ReleaseLock":
+		return s.releaseLock(ctx, req.Payload)
+	case "TestLock":
+		return s.testLock(ctx, req.Payload)
+	case "GetLock":
+		return s.getLock(ctx, req.Payload)
+	case "ListLocks":
+		return s.listLocks(ctx, req.Payload)
+	case "CleanupExpiredLocks":
+		return s.cleanupExpiredLocks(ctx)
+
 	default:
 		return &pb.MetadataResponse{Error: fmt.Sprintf("unknown operation: %s", req.Operation)}, nil
 	}
@@ -597,3 +613,91 @@ func (s *GRPCServer) listNodeMetas(ctx context.Context) (*pb.MetadataResponse, e
 	}
 	return okResp(metas)
 }
+
+// ---- Lock operations ----
+
+func (s *GRPCServer) acquireLock(ctx context.Context, payload []byte) (*pb.MetadataResponse, error) {
+	var args AcquireLockArgs
+	if err := json.Unmarshal(payload, &args); err != nil {
+		return errResp(fmt.Errorf("unmarshal AcquireLockArgs: %w", err)), nil
+	}
+	result, err := s.store.AcquireLock(ctx, &args)
+	if err != nil {
+		return errResp(err), nil
+	}
+	return okResp(result)
+}
+
+func (s *GRPCServer) renewLock(ctx context.Context, payload []byte) (*pb.MetadataResponse, error) {
+	var args RenewLockArgs
+	if err := json.Unmarshal(payload, &args); err != nil {
+		return errResp(fmt.Errorf("unmarshal RenewLockArgs: %w", err)), nil
+	}
+	lease, err := s.store.RenewLock(ctx, &args)
+	if err != nil {
+		return errResp(err), nil
+	}
+	return okResp(lease)
+}
+
+func (s *GRPCServer) releaseLock(ctx context.Context, payload []byte) (*pb.MetadataResponse, error) {
+	var args ReleaseLockArgs
+	if err := json.Unmarshal(payload, &args); err != nil {
+		return errResp(fmt.Errorf("unmarshal ReleaseLockArgs: %w", err)), nil
+	}
+	if err := s.store.ReleaseLock(ctx, &args); err != nil {
+		return errResp(err), nil
+	}
+	return &pb.MetadataResponse{}, nil
+}
+
+func (s *GRPCServer) testLock(ctx context.Context, payload []byte) (*pb.MetadataResponse, error) {
+	var args TestLockArgs
+	if err := json.Unmarshal(payload, &args); err != nil {
+		return errResp(fmt.Errorf("unmarshal TestLockArgs: %w", err)), nil
+	}
+	lease, err := s.store.TestLock(ctx, &args)
+	if err != nil {
+		return errResp(err), nil
+	}
+	return okResp(lease)
+}
+
+func (s *GRPCServer) getLock(ctx context.Context, payload []byte) (*pb.MetadataResponse, error) {
+	var args struct {
+		LeaseID string `json:"leaseID"`
+	}
+	if err := json.Unmarshal(payload, &args); err != nil {
+		return errResp(fmt.Errorf("unmarshal args: %w", err)), nil
+	}
+	lease, err := s.store.GetLock(ctx, args.LeaseID)
+	if err != nil {
+		return errResp(err), nil
+	}
+	return okResp(lease)
+}
+
+func (s *GRPCServer) listLocks(ctx context.Context, payload []byte) (*pb.MetadataResponse, error) {
+	var args struct {
+		VolumeID string `json:"volumeID,omitempty"`
+	}
+	if err := json.Unmarshal(payload, &args); err != nil {
+		return errResp(fmt.Errorf("unmarshal args: %w", err)), nil
+	}
+	locks, err := s.store.ListLocks(ctx, args.VolumeID)
+	if err != nil {
+		return errResp(err), nil
+	}
+	return okResp(locks)
+}
+
+func (s *GRPCServer) cleanupExpiredLocks(ctx context.Context) (*pb.MetadataResponse, error) {
+	count, err := s.store.CleanupExpiredLocks(ctx)
+	if err != nil {
+		return errResp(err), nil
+	}
+	return okResp(struct {
+		Cleaned int `json:"cleaned"`
+	}{Cleaned: count})
+}
+

--- a/internal/metadata/lock_meta.go
+++ b/internal/metadata/lock_meta.go
@@ -1,0 +1,184 @@
+package metadata
+
+import (
+	"context"
+	"fmt"
+	"time"
+)
+
+// LockType represents the type of a file lock.
+type LockType int
+
+const (
+	// LockRead is a shared read lock.
+	LockRead LockType = iota
+	// LockWrite is an exclusive write lock.
+	LockWrite
+)
+
+func (lt LockType) String() string {
+	switch lt {
+	case LockRead:
+		return "read"
+	case LockWrite:
+		return "write"
+	default:
+		return "unknown"
+	}
+}
+
+// LockLease represents a distributed file lock lease.
+type LockLease struct {
+	// LeaseID is the unique identifier for this lease.
+	LeaseID string `json:"leaseID"`
+	// Owner identifies the client holding the lock (typically client:hostname:pid).
+	Owner string `json:"owner"`
+	// VolumeID is the volume this lock applies to (optional, for namespace isolation).
+	VolumeID string `json:"volumeID,omitempty"`
+	// Ino is the inode number being locked.
+	Ino uint64 `json:"ino"`
+	// Start is the byte offset where the lock begins.
+	Start int64 `json:"start"`
+	// End is the byte offset where the lock ends (-1 means EOF).
+	End int64 `json:"end"`
+	// Type is the lock type (read or write).
+	Type LockType `json:"type"`
+	// ExpiresAt is the Unix nanosecond timestamp when this lease expires.
+	ExpiresAt int64 `json:"expiresAt"`
+	// FilerID identifies which filer instance granted this lock.
+	FilerID string `json:"filerID,omitempty"`
+}
+
+// IsExpired returns true if the lease has expired.
+func (l *LockLease) IsExpired() bool {
+	return time.Now().UnixNano() > l.ExpiresAt
+}
+
+// RemainingDuration returns the remaining duration until expiration.
+func (l *LockLease) RemainingDuration() time.Duration {
+	expiration := time.Unix(0, l.ExpiresAt)
+	remaining := time.Until(expiration)
+	if remaining < 0 {
+		return 0
+	}
+	return remaining
+}
+
+// lockKey generates the storage key for a lock lease.
+func lockKey(leaseID string) string {
+	return leaseID
+}
+
+// lockIndexKey is the key for the lock index (maps inode to list of lease IDs).
+func lockIndexKey(ino uint64) string {
+	return fmt.Sprintf("index:%d", ino)
+}
+
+// lockIndex stores the mapping from inode to lease IDs.
+type lockIndex struct {
+	Ino      uint64   `json:"ino"`
+	LeaseIDs []string `json:"leaseIDs"`
+}
+
+// AcquireLockArgs contains the arguments for acquiring a lock.
+type AcquireLockArgs struct {
+	Owner    string        `json:"owner"`
+	VolumeID string        `json:"volumeID,omitempty"`
+	Ino      uint64        `json:"ino"`
+	Start    int64         `json:"start"`
+	End      int64         `json:"end"`
+	Type     LockType      `json:"type"`
+	TTL      time.Duration `json:"ttl"` // Lease TTL
+	FilerID  string        `json:"filerID,omitempty"`
+}
+
+// RenewLockArgs contains the arguments for renewing a lock.
+type RenewLockArgs struct {
+	LeaseID string        `json:"leaseID"`
+	TTL     time.Duration `json:"ttl"`
+}
+
+// ReleaseLockArgs contains the arguments for releasing a lock.
+type ReleaseLockArgs struct {
+	LeaseID string `json:"leaseID"`
+	Owner   string `json:"owner"`
+}
+
+// TestLockArgs contains the arguments for testing a lock.
+type TestLockArgs struct {
+	VolumeID string   `json:"volumeID,omitempty"`
+	Ino      uint64   `json:"ino"`
+	Start    int64    `json:"start"`
+	End      int64    `json:"end"`
+	Type     LockType `json:"type"`
+}
+
+// AcquireLockResult contains the result of acquiring a lock.
+type AcquireLockResult struct {
+	LeaseID          string `json:"leaseID"`
+	ExpiresAt        int64  `json:"expiresAt"`
+	ConflictingOwner string `json:"conflictingOwner,omitempty"`
+}
+
+// overlaps returns true if two byte ranges overlap.
+// End == -1 means the range extends to EOF.
+func overlaps(s1, e1, s2, e2 int64) bool {
+	// Normalize: treat -1 (EOF) as max int64 for comparison.
+	if e1 == -1 {
+		e1 = int64(^uint64(0) >> 1) // math.MaxInt64
+	}
+	if e2 == -1 {
+		e2 = int64(^uint64(0) >> 1)
+	}
+	return s1 < e2 && s2 < e1
+}
+
+// conflicts returns true if two locks conflict.
+// Write locks conflict with any overlapping lock from a different owner.
+// Read locks conflict only with overlapping write locks from a different owner.
+func conflicts(a, b *LockLease) bool {
+	// Skip expired locks
+	if a.IsExpired() || b.IsExpired() {
+		return false
+	}
+	if a.Owner == b.Owner {
+		return false
+	}
+	if !overlaps(a.Start, a.End, b.Start, b.End) {
+		return false
+	}
+	// Two read locks never conflict.
+	if a.Type == LockRead && b.Type == LockRead {
+		return false
+	}
+	return true
+}
+
+// FSM operations for locks are applied through the standard apply mechanism
+// using the bucketLocks bucket. The lock manager handles coordination.
+
+// LockClient defines the interface for distributed lock operations.
+// Both RaftStore (direct) and GRPCClient (remote) implement this interface.
+type LockClient interface {
+	AcquireLock(ctx context.Context, args *AcquireLockArgs) (*AcquireLockResult, error)
+	RenewLock(ctx context.Context, args *RenewLockArgs) (*LockLease, error)
+	ReleaseLock(ctx context.Context, args *ReleaseLockArgs) error
+	TestLock(ctx context.Context, args *TestLockArgs) (*LockLease, error)
+	GetLock(ctx context.Context, leaseID string) (*LockLease, error)
+	ListLocks(ctx context.Context, volumeID string) ([]*LockLease, error)
+	CleanupExpiredLocks(ctx context.Context) (int, error)
+}
+
+// initLocksBucket ensures the locks bucket exists in the FSM.
+func initLocksBucket(fsm MetadataFSM) error {
+	// The FSM dynamically creates buckets on first use, so no explicit init needed.
+	// This is a no-op but documents the requirement.
+	return nil
+}
+
+// GenerateLeaseID creates a unique lease ID.
+func GenerateLeaseID() string {
+	// Use nanosecond timestamp + random component for uniqueness.
+	// In production with Raft, we could use a monotonic counter.
+	return fmt.Sprintf("lease-%d-%d", time.Now().UnixNano(), time.Now().Nanosecond()%10000)
+}

--- a/internal/metadata/lock_test.go
+++ b/internal/metadata/lock_test.go
@@ -1,0 +1,700 @@
+package metadata
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/raft"
+)
+
+// mockLockStore is a minimal lock store implementation for testing.
+// It directly manipulates the FSM without going through Raft.
+type mockLockStore struct {
+	fsm *FSM
+}
+
+func newMockLockStore() *mockLockStore {
+	return &mockLockStore{fsm: NewFSM()}
+}
+
+func (m *mockLockStore) applyOp(op *fsmOp) error {
+	data, err := json.Marshal(op)
+	if err != nil {
+		return err
+	}
+	// Directly apply to FSM using the internal applyLog representation.
+	log := raft.Log{
+		Data: data,
+	}
+	result := m.fsm.Apply(&log)
+	if result != nil {
+		if err, ok := result.(error); ok {
+			return err
+		}
+	}
+	return nil
+}
+
+func (m *mockLockStore) acquireLockDirect(args *AcquireLockArgs) (*AcquireLockResult, error) {
+	leaseID := GenerateLeaseID()
+	lease := &LockLease{
+		LeaseID:   leaseID,
+		Owner:     args.Owner,
+		VolumeID:  args.VolumeID,
+		Ino:       args.Ino,
+		Start:     args.Start,
+		End:       args.End,
+		Type:      args.Type,
+		ExpiresAt: time.Now().Add(args.TTL).UnixNano(),
+		FilerID:   args.FilerID,
+	}
+
+	// Check for conflicts.
+	locks, _ := m.getLocksForInode(args.Ino)
+	for _, existing := range locks {
+		if existing.IsExpired() {
+			continue
+		}
+		if conflicts(lease, existing) {
+			return &AcquireLockResult{ConflictingOwner: existing.Owner},
+				fmt.Errorf("lock conflict: owner %q holds conflicting lock", existing.Owner)
+		}
+	}
+
+	// Store lease.
+	leaseData, _ := json.Marshal(lease)
+	if err := m.applyOp(&fsmOp{Op: opPut, Bucket: bucketLocks, Key: lockKey(leaseID), Value: leaseData}); err != nil {
+		return nil, err
+	}
+
+	// Update index.
+	if err := m.addLockToIndex(args.Ino, leaseID); err != nil {
+		m.applyOp(&fsmOp{Op: opDelete, Bucket: bucketLocks, Key: lockKey(leaseID)})
+		return nil, err
+	}
+
+	return &AcquireLockResult{LeaseID: leaseID, ExpiresAt: lease.ExpiresAt}, nil
+}
+
+func (m *mockLockStore) getLock(leaseID string) (*LockLease, error) {
+	data, err := m.fsm.Get(bucketLocks, lockKey(leaseID))
+	if err != nil {
+		return nil, err
+	}
+	var lease LockLease
+	if err := json.Unmarshal(data, &lease); err != nil {
+		return nil, err
+	}
+	return &lease, nil
+}
+
+func (m *mockLockStore) renewLock(leaseID string, ttl time.Duration) (*LockLease, error) {
+	lease, err := m.getLock(leaseID)
+	if err != nil {
+		return nil, err
+	}
+	if lease.IsExpired() {
+		return nil, fmt.Errorf("lease expired")
+	}
+	lease.ExpiresAt = time.Now().Add(ttl).UnixNano()
+	leaseData, _ := json.Marshal(lease)
+	if err := m.applyOp(&fsmOp{Op: opPut, Bucket: bucketLocks, Key: lockKey(leaseID), Value: leaseData}); err != nil {
+		return nil, err
+	}
+	return lease, nil
+}
+
+func (m *mockLockStore) releaseLock(leaseID string) error {
+	lease, err := m.getLock(leaseID)
+	if err != nil {
+		return err
+	}
+	_ = m.applyOp(&fsmOp{Op: opDelete, Bucket: bucketLocks, Key: lockKey(leaseID)})
+	_ = m.removeLockFromIndex(lease.Ino, leaseID)
+	return nil
+}
+
+func (m *mockLockStore) testLock(args *TestLockArgs) (*LockLease, error) {
+	locks, _ := m.getLocksForInode(args.Ino)
+	candidate := &LockLease{
+		VolumeID:  args.VolumeID,
+		Ino:       args.Ino,
+		Start:     args.Start,
+		End:       args.End,
+		Type:      args.Type,
+		ExpiresAt: time.Now().Add(time.Minute).UnixNano(), // Set far future so it's not expired
+	}
+	for _, existing := range locks {
+		if existing.IsExpired() {
+			continue
+		}
+		if conflicts(candidate, existing) {
+			return existing, nil
+		}
+	}
+	return nil, nil
+}
+
+func (m *mockLockStore) cleanupExpiredLocks() (int, error) {
+	all, _ := m.fsm.GetAll(bucketLocks)
+	now := time.Now().UnixNano()
+	cleaned := 0
+	for key, data := range all {
+		// Skip index entries (they start with "index:")
+		if len(key) >= 6 && key[:6] == "index:" {
+			continue
+		}
+		var lease LockLease
+		if err := json.Unmarshal(data, &lease); err != nil {
+			continue
+		}
+		if lease.ExpiresAt < now {
+			_ = m.applyOp(&fsmOp{Op: opDelete, Bucket: bucketLocks, Key: key})
+			_ = m.removeLockFromIndex(lease.Ino, lease.LeaseID)
+			cleaned++
+		}
+	}
+	return cleaned, nil
+}
+
+func (m *mockLockStore) getLocksForInode(ino uint64) ([]*LockLease, error) {
+	indexData, err := m.fsm.Get(bucketLocks, lockIndexKey(ino))
+	if err != nil {
+		return nil, nil
+	}
+	var index lockIndex
+	if err := json.Unmarshal(indexData, &index); err != nil {
+		return nil, err
+	}
+	var locks []*LockLease
+	for _, leaseID := range index.LeaseIDs {
+		leaseData, err := m.fsm.Get(bucketLocks, lockKey(leaseID))
+		if err != nil {
+			continue
+		}
+		var lease LockLease
+		if err := json.Unmarshal(leaseData, &lease); err != nil {
+			continue
+		}
+		locks = append(locks, &lease)
+	}
+	return locks, nil
+}
+
+func (m *mockLockStore) addLockToIndex(ino uint64, leaseID string) error {
+	indexData, err := m.fsm.Get(bucketLocks, lockIndexKey(ino))
+	if err != nil {
+		index := lockIndex{Ino: ino, LeaseIDs: []string{leaseID}}
+		data, _ := json.Marshal(index)
+		return m.applyOp(&fsmOp{Op: opPut, Bucket: bucketLocks, Key: lockIndexKey(ino), Value: data})
+	}
+	var index lockIndex
+	_ = json.Unmarshal(indexData, &index)
+	index.LeaseIDs = append(index.LeaseIDs, leaseID)
+	data, _ := json.Marshal(index)
+	return m.applyOp(&fsmOp{Op: opPut, Bucket: bucketLocks, Key: lockIndexKey(ino), Value: data})
+}
+
+func (m *mockLockStore) removeLockFromIndex(ino uint64, leaseID string) error {
+	indexData, err := m.fsm.Get(bucketLocks, lockIndexKey(ino))
+	if err != nil {
+		return nil
+	}
+	var index lockIndex
+	_ = json.Unmarshal(indexData, &index)
+	newLeaseIDs := make([]string, 0, len(index.LeaseIDs))
+	for _, id := range index.LeaseIDs {
+		if id != leaseID {
+			newLeaseIDs = append(newLeaseIDs, id)
+		}
+	}
+	if len(newLeaseIDs) == 0 {
+		return m.applyOp(&fsmOp{Op: opDelete, Bucket: bucketLocks, Key: lockIndexKey(ino)})
+	}
+	index.LeaseIDs = newLeaseIDs
+	data, _ := json.Marshal(index)
+	return m.applyOp(&fsmOp{Op: opPut, Bucket: bucketLocks, Key: lockIndexKey(ino), Value: data})
+}
+
+// TestAcquireLock tests acquiring a lock.
+func TestAcquireLock(t *testing.T) {
+	store := newMockLockStore()
+
+	args := &AcquireLockArgs{
+		Owner:   "client1",
+		Ino:     1,
+		Start:   0,
+		End:     100,
+		Type:    LockWrite,
+		TTL:     time.Minute,
+		FilerID: "filer1",
+	}
+
+	result, err := store.acquireLockDirect(args)
+	if err != nil {
+		t.Fatalf("failed to acquire lock: %v", err)
+	}
+
+	if result.LeaseID == "" {
+		t.Fatal("expected non-empty lease ID")
+	}
+
+	// Verify the lock exists.
+	lease, err := store.getLock(result.LeaseID)
+	if err != nil {
+		t.Fatalf("failed to get lease: %v", err)
+	}
+
+	if lease.Owner != "client1" {
+		t.Errorf("expected owner client1, got %s", lease.Owner)
+	}
+	if lease.Ino != 1 {
+		t.Errorf("expected ino 1, got %d", lease.Ino)
+	}
+}
+
+// TestAcquireLockConflict tests that conflicting locks are rejected.
+func TestAcquireLockConflict(t *testing.T) {
+	store := newMockLockStore()
+
+	// Acquire first lock.
+	args1 := &AcquireLockArgs{
+		Owner:   "client1",
+		Ino:     1,
+		Start:   0,
+		End:     100,
+		Type:    LockWrite,
+		TTL:     time.Minute,
+		FilerID: "filer1",
+	}
+
+	_, err := store.acquireLockDirect(args1)
+	if err != nil {
+		t.Fatalf("failed to acquire first lock: %v", err)
+	}
+
+	// Try to acquire conflicting lock from different client.
+	args2 := &AcquireLockArgs{
+		Owner:   "client2",
+		Ino:     1,
+		Start:   50,
+		End:     150,
+		Type:    LockWrite,
+		TTL:     time.Minute,
+		FilerID: "filer1",
+	}
+
+	result, err := store.acquireLockDirect(args2)
+	if err == nil {
+		t.Fatal("expected conflict error, got nil")
+	}
+	if result.ConflictingOwner != "client1" {
+		t.Errorf("expected conflicting owner client1, got %s", result.ConflictingOwner)
+	}
+}
+
+// TestReadLockShared tests that multiple read locks can coexist.
+func TestReadLockShared(t *testing.T) {
+	store := newMockLockStore()
+
+	// Acquire first read lock.
+	args1 := &AcquireLockArgs{
+		Owner:   "client1",
+		Ino:     1,
+		Start:   0,
+		End:     100,
+		Type:    LockRead,
+		TTL:     time.Minute,
+		FilerID: "filer1",
+	}
+
+	result1, err := store.acquireLockDirect(args1)
+	if err != nil {
+		t.Fatalf("failed to acquire first read lock: %v", err)
+	}
+
+	// Acquire second read lock from different client.
+	args2 := &AcquireLockArgs{
+		Owner:   "client2",
+		Ino:     1,
+		Start:   0,
+		End:     100,
+		Type:    LockRead,
+		TTL:     time.Minute,
+		FilerID: "filer1",
+	}
+
+	result2, err := store.acquireLockDirect(args2)
+	if err != nil {
+		t.Fatalf("failed to acquire second read lock: %v", err)
+	}
+
+	if result1.LeaseID == result2.LeaseID {
+		t.Fatal("expected different lease IDs")
+	}
+}
+
+// TestReadWriteConflict tests that read and write locks conflict.
+func TestReadWriteConflict(t *testing.T) {
+	store := newMockLockStore()
+
+	// Acquire read lock.
+	args1 := &AcquireLockArgs{
+		Owner:   "client1",
+		Ino:     1,
+		Start:   0,
+		End:     100,
+		Type:    LockRead,
+		TTL:     time.Minute,
+		FilerID: "filer1",
+	}
+
+	if _, err := store.acquireLockDirect(args1); err != nil {
+		t.Fatalf("failed to acquire read lock: %v", err)
+	}
+
+	// Try to acquire overlapping write lock.
+	args2 := &AcquireLockArgs{
+		Owner:   "client2",
+		Ino:     1,
+		Start:   50,
+		End:     150,
+		Type:    LockWrite,
+		TTL:     time.Minute,
+		FilerID: "filer1",
+	}
+
+	result, err := store.acquireLockDirect(args2)
+	if err == nil {
+		t.Fatal("expected conflict error, got nil")
+	}
+	if result.ConflictingOwner != "client1" {
+		t.Errorf("expected conflicting owner client1, got %s", result.ConflictingOwner)
+	}
+}
+
+// TestRenewLock tests renewing a lock lease.
+func TestRenewLock(t *testing.T) {
+	store := newMockLockStore()
+
+	// Acquire lock.
+	args := &AcquireLockArgs{
+		Owner:   "client1",
+		Ino:     1,
+		Start:   0,
+		End:     100,
+		Type:    LockWrite,
+		TTL:     time.Second,
+		FilerID: "filer1",
+	}
+
+	result, err := store.acquireLockDirect(args)
+	if err != nil {
+		t.Fatalf("failed to acquire lock: %v", err)
+	}
+
+	// Get original expiration.
+	lease, err := store.getLock(result.LeaseID)
+	if err != nil {
+		t.Fatalf("failed to get lease: %v", err)
+	}
+	originalExpiry := lease.ExpiresAt
+
+	// Wait a bit and renew.
+	time.Sleep(100 * time.Millisecond)
+
+	renewed, err := store.renewLock(result.LeaseID, time.Minute)
+	if err != nil {
+		t.Fatalf("failed to renew lock: %v", err)
+	}
+
+	if renewed.ExpiresAt <= originalExpiry {
+		t.Errorf("expected renewed expiry %d > original %d", renewed.ExpiresAt, originalExpiry)
+	}
+}
+
+// TestReleaseLock tests releasing a lock.
+func TestReleaseLock(t *testing.T) {
+	store := newMockLockStore()
+
+	// Acquire lock.
+	args := &AcquireLockArgs{
+		Owner:   "client1",
+		Ino:     1,
+		Start:   0,
+		End:     100,
+		Type:    LockWrite,
+		TTL:     time.Minute,
+		FilerID: "filer1",
+	}
+
+	result, err := store.acquireLockDirect(args)
+	if err != nil {
+		t.Fatalf("failed to acquire lock: %v", err)
+	}
+
+	// Release lock.
+	if err := store.releaseLock(result.LeaseID); err != nil {
+		t.Fatalf("failed to release lock: %v", err)
+	}
+
+	// Verify lock is gone.
+	if _, err := store.getLock(result.LeaseID); err == nil {
+		t.Fatal("expected error getting released lock")
+	}
+
+	// Another client should now be able to acquire the lock.
+	args2 := &AcquireLockArgs{
+		Owner:   "client2",
+		Ino:     1,
+		Start:   0,
+		End:     100,
+		Type:    LockWrite,
+		TTL:     time.Minute,
+		FilerID: "filer1",
+	}
+
+	if _, err := store.acquireLockDirect(args2); err != nil {
+		t.Errorf("expected to acquire lock after release: %v", err)
+	}
+}
+
+// TestLockExpiry tests that expired locks don't conflict.
+func TestLockExpiry(t *testing.T) {
+	store := newMockLockStore()
+
+	// Acquire lock with short TTL.
+	args := &AcquireLockArgs{
+		Owner:   "client1",
+		Ino:     1,
+		Start:   0,
+		End:     100,
+		Type:    LockWrite,
+		TTL:     100 * time.Millisecond,
+		FilerID: "filer1",
+	}
+
+	result, err := store.acquireLockDirect(args)
+	if err != nil {
+		t.Fatalf("failed to acquire lock: %v", err)
+	}
+
+	// Wait for expiry.
+	time.Sleep(200 * time.Millisecond)
+
+	// Verify lock is expired.
+	lease, err := store.getLock(result.LeaseID)
+	if err != nil {
+		t.Fatalf("failed to get lease: %v", err)
+	}
+	if !lease.IsExpired() {
+		t.Error("expected lease to be expired")
+	}
+
+	// Another client should be able to acquire the lock.
+	args2 := &AcquireLockArgs{
+		Owner:   "client2",
+		Ino:     1,
+		Start:   0,
+		End:     100,
+		Type:    LockWrite,
+		TTL:     time.Minute,
+		FilerID: "filer1",
+	}
+
+	if _, err := store.acquireLockDirect(args2); err != nil {
+		t.Errorf("expected to acquire lock after expiry: %v", err)
+	}
+}
+
+// TestNonOverlappingLocks tests that non-overlapping locks don't conflict.
+func TestNonOverlappingLocks(t *testing.T) {
+	store := newMockLockStore()
+
+	// Acquire first lock.
+	args1 := &AcquireLockArgs{
+		Owner:   "client1",
+		Ino:     1,
+		Start:   0,
+		End:     50,
+		Type:    LockWrite,
+		TTL:     time.Minute,
+		FilerID: "filer1",
+	}
+
+	if _, err := store.acquireLockDirect(args1); err != nil {
+		t.Fatalf("failed to acquire first lock: %v", err)
+	}
+
+	// Acquire non-overlapping lock from different client.
+	args2 := &AcquireLockArgs{
+		Owner:   "client2",
+		Ino:     1,
+		Start:   50,
+		End:     100,
+		Type:    LockWrite,
+		TTL:     time.Minute,
+		FilerID: "filer1",
+	}
+
+	if _, err := store.acquireLockDirect(args2); err != nil {
+		t.Errorf("non-overlapping locks should not conflict: %v", err)
+	}
+}
+
+// TestCleanupExpiredLocks tests the cleanup function.
+func TestCleanupExpiredLocks(t *testing.T) {
+	store := newMockLockStore()
+
+	// Acquire locks with different TTLs.
+	args1 := &AcquireLockArgs{
+		Owner:   "client1",
+		Ino:     1,
+		Start:   0,
+		End:     100,
+		Type:    LockWrite,
+		TTL:     100 * time.Millisecond,
+		FilerID: "filer1",
+	}
+
+	args2 := &AcquireLockArgs{
+		Owner:   "client2",
+		Ino:     2,
+		Start:   0,
+		End:     100,
+		Type:    LockWrite,
+		TTL:     time.Minute,
+		FilerID: "filer1",
+	}
+
+	if _, err := store.acquireLockDirect(args1); err != nil {
+		t.Fatalf("failed to acquire first lock: %v", err)
+	}
+	if _, err := store.acquireLockDirect(args2); err != nil {
+		t.Fatalf("failed to acquire second lock: %v", err)
+	}
+
+	// Wait for first lock to expire.
+	time.Sleep(200 * time.Millisecond)
+
+	// Run cleanup.
+	count, err := store.cleanupExpiredLocks()
+	if err != nil {
+		t.Fatalf("cleanup failed: %v", err)
+	}
+
+	if count != 1 {
+		t.Errorf("expected to clean 1 lock, got %d", count)
+	}
+
+	// Verify second lock still exists by trying to acquire a conflicting lock.
+	args3 := &AcquireLockArgs{
+		Owner:   "client3",
+		Ino:     2,
+		Start:   0,
+		End:     100,
+		Type:    LockWrite,
+		TTL:     time.Minute,
+		FilerID: "filer1",
+	}
+
+	result, err := store.acquireLockDirect(args3)
+	if err == nil {
+		t.Fatal("expected conflict for second lock")
+	}
+	if result.ConflictingOwner != "client2" {
+		t.Errorf("expected conflicting owner client2, got %s", result.ConflictingOwner)
+	}
+}
+
+// TestSameOwnerNoConflict tests that the same owner doesn't conflict with itself.
+func TestSameOwnerNoConflict(t *testing.T) {
+	store := newMockLockStore()
+
+	// Acquire first lock.
+	args1 := &AcquireLockArgs{
+		Owner:   "client1",
+		Ino:     1,
+		Start:   0,
+		End:     100,
+		Type:    LockWrite,
+		TTL:     time.Minute,
+		FilerID: "filer1",
+	}
+
+	if _, err := store.acquireLockDirect(args1); err != nil {
+		t.Fatalf("failed to acquire first lock: %v", err)
+	}
+
+	// Acquire overlapping lock from same owner.
+	args2 := &AcquireLockArgs{
+		Owner:   "client1",
+		Ino:     1,
+		Start:   50,
+		End:     150,
+		Type:    LockWrite,
+		TTL:     time.Minute,
+		FilerID: "filer1",
+	}
+
+	if _, err := store.acquireLockDirect(args2); err != nil {
+		t.Errorf("same owner should not conflict with itself: %v", err)
+	}
+}
+
+// TestTestLock tests the TestLock operation.
+func TestTestLock(t *testing.T) {
+	store := newMockLockStore()
+
+	// Acquire a lock.
+	args := &AcquireLockArgs{
+		Owner:   "client1",
+		Ino:     1,
+		Start:   0,
+		End:     100,
+		Type:    LockWrite,
+		TTL:     time.Minute,
+		FilerID: "filer1",
+	}
+
+	if _, err := store.acquireLockDirect(args); err != nil {
+		t.Fatalf("failed to acquire lock: %v", err)
+	}
+
+	// Test conflicting lock.
+	testArgs := &TestLockArgs{
+		Ino:   1,
+		Start: 50,
+		End:   150,
+		Type:  LockWrite,
+	}
+
+	conflict, err := store.testLock(testArgs)
+	if err != nil {
+		t.Fatalf("TestLock failed: %v", err)
+	}
+	if conflict == nil {
+		t.Fatal("expected conflict, got nil")
+	}
+	if conflict.Owner != "client1" {
+		t.Errorf("expected conflicting owner client1, got %s", conflict.Owner)
+	}
+
+	// Test non-conflicting lock.
+	testArgs2 := &TestLockArgs{
+		Ino:   1,
+		Start: 200,
+		End:   300,
+		Type:  LockWrite,
+	}
+
+	conflict, err = store.testLock(testArgs2)
+	if err != nil {
+		t.Fatalf("TestLock failed: %v", err)
+	}
+	if conflict != nil {
+		t.Errorf("expected no conflict, got %v", conflict)
+	}
+}

--- a/internal/metadata/store.go
+++ b/internal/metadata/store.go
@@ -364,6 +364,338 @@ func (s *RaftStore) DeletePlacementMap(_ context.Context, chunkID string) error 
 	return s.apply(&fsmOp{Op: opDelete, Bucket: bucketPlacements, Key: chunkID})
 }
 
+// ---- Lock lease operations ----
+
+// AcquireLock attempts to acquire a file lock lease. If successful, returns the lease ID.
+// If a conflicting lock exists, returns an error with the conflicting owner.
+func (s *RaftStore) AcquireLock(ctx context.Context, args *AcquireLockArgs) (*AcquireLockResult, error) {
+	// First check for conflicts by reading existing locks for this inode.
+	locks, err := s.getLocksForInode(ctx, args.Ino)
+	if err != nil {
+		return nil, fmt.Errorf("checking existing locks: %w", err)
+	}
+
+	// Filter out expired locks and check for conflicts.
+	candidateLock := &LockLease{
+		Owner:     args.Owner,
+		VolumeID:  args.VolumeID,
+		Ino:       args.Ino,
+		Start:     args.Start,
+		End:       args.End,
+		Type:      args.Type,
+		ExpiresAt: time.Now().Add(args.TTL).UnixNano(),
+		FilerID:   args.FilerID,
+	}
+
+	for _, existing := range locks {
+		if existing.IsExpired() {
+			// Clean up expired lock asynchronously.
+			go s.ReleaseLock(context.Background(), &ReleaseLockArgs{
+				LeaseID: existing.LeaseID,
+				Owner:   existing.Owner,
+			})
+			continue
+		}
+		if conflicts(candidateLock, existing) {
+			return &AcquireLockResult{
+				ConflictingOwner: existing.Owner,
+			}, fmt.Errorf("lock conflict: owner %q holds conflicting %s lock on inode %d [%d,%d)",
+				existing.Owner, existing.Type, existing.Ino, existing.Start, existing.End)
+		}
+	}
+
+	// No conflicts, create the lease.
+	leaseID := GenerateLeaseID()
+	candidateLock.LeaseID = leaseID
+
+	// Store the lease.
+	leaseData, err := json.Marshal(candidateLock)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling lease: %w", err)
+	}
+	if err := s.apply(&fsmOp{Op: opPut, Bucket: bucketLocks, Key: lockKey(leaseID), Value: leaseData}); err != nil {
+		return nil, fmt.Errorf("storing lease: %w", err)
+	}
+
+	// Update the index.
+	if err := s.addLockToIndex(ctx, args.Ino, leaseID); err != nil {
+		// Best effort cleanup on index update failure.
+		_ = s.apply(&fsmOp{Op: opDelete, Bucket: bucketLocks, Key: lockKey(leaseID)})
+		return nil, fmt.Errorf("updating lock index: %w", err)
+	}
+
+	return &AcquireLockResult{
+		LeaseID:   leaseID,
+		ExpiresAt: candidateLock.ExpiresAt,
+	}, nil
+}
+
+// RenewLock extends the expiration time of an existing lock lease.
+func (s *RaftStore) RenewLock(ctx context.Context, args *RenewLockArgs) (*LockLease, error) {
+	leaseData, err := s.fsm.Get(bucketLocks, lockKey(args.LeaseID))
+	if err != nil {
+		return nil, fmt.Errorf("lease not found: %w", err)
+	}
+
+	var lease LockLease
+	if err := json.Unmarshal(leaseData, &lease); err != nil {
+		return nil, fmt.Errorf("unmarshaling lease: %w", err)
+	}
+
+	if lease.IsExpired() {
+		return nil, fmt.Errorf("cannot renew expired lease %s", args.LeaseID)
+	}
+
+	// Update expiration.
+	lease.ExpiresAt = time.Now().Add(args.TTL).UnixNano()
+
+	newLeaseData, err := json.Marshal(lease)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling lease: %w", err)
+	}
+	if err := s.apply(&fsmOp{Op: opPut, Bucket: bucketLocks, Key: lockKey(args.LeaseID), Value: newLeaseData}); err != nil {
+		return nil, fmt.Errorf("storing renewed lease: %w", err)
+	}
+
+	return &lease, nil
+}
+
+// ReleaseLock releases a lock lease, removing it from the metadata store.
+func (s *RaftStore) ReleaseLock(ctx context.Context, args *ReleaseLockArgs) error {
+	// Verify the lease exists and belongs to the owner (if specified).
+	leaseData, err := s.fsm.Get(bucketLocks, lockKey(args.LeaseID))
+	if err != nil {
+		return fmt.Errorf("lease not found: %w", err)
+	}
+
+	var lease LockLease
+	if err := json.Unmarshal(leaseData, &lease); err != nil {
+		return fmt.Errorf("unmarshaling lease: %w", err)
+	}
+
+	if args.Owner != "" && lease.Owner != args.Owner {
+		return fmt.Errorf("lease owner mismatch: expected %q, got %q", lease.Owner, args.Owner)
+	}
+
+	// Remove the lease.
+	if err := s.apply(&fsmOp{Op: opDelete, Bucket: bucketLocks, Key: lockKey(args.LeaseID)}); err != nil {
+		return fmt.Errorf("deleting lease: %w", err)
+	}
+
+	// Remove from index.
+	if err := s.removeLockFromIndex(ctx, lease.Ino, args.LeaseID); err != nil {
+		// Log but don't fail - stale index entries are cleaned up during reads.
+		return fmt.Errorf("removing from index: %w", err)
+	}
+
+	return nil
+}
+
+// TestLock checks if a lock could be acquired without actually acquiring it.
+// Returns nil if no conflict exists, or the conflicting lock if one does.
+func (s *RaftStore) TestLock(ctx context.Context, args *TestLockArgs) (*LockLease, error) {
+	locks, err := s.getLocksForInode(ctx, args.Ino)
+	if err != nil {
+		return nil, fmt.Errorf("checking existing locks: %w", err)
+	}
+
+	candidateLock := &LockLease{
+		VolumeID: args.VolumeID,
+		Ino:      args.Ino,
+		Start:    args.Start,
+		End:      args.End,
+		Type:     args.Type,
+	}
+
+	for _, existing := range locks {
+		if existing.IsExpired() {
+			continue
+		}
+		if conflicts(candidateLock, existing) {
+			return existing, nil
+		}
+	}
+
+	return nil, nil
+}
+
+// GetLock retrieves a lock lease by ID.
+func (s *RaftStore) GetLock(ctx context.Context, leaseID string) (*LockLease, error) {
+	leaseData, err := s.fsm.Get(bucketLocks, lockKey(leaseID))
+	if err != nil {
+		return nil, fmt.Errorf("lease not found: %w", err)
+	}
+
+	var lease LockLease
+	if err := json.Unmarshal(leaseData, &lease); err != nil {
+		return nil, fmt.Errorf("unmarshaling lease: %w", err)
+	}
+
+	return &lease, nil
+}
+
+// ListLocks returns all active (non-expired) locks, optionally filtered by volume ID.
+func (s *RaftStore) ListLocks(_ context.Context, volumeID string) ([]*LockLease, error) {
+	all, err := s.fsm.GetAll(bucketLocks)
+	if err != nil {
+		return nil, fmt.Errorf("listing locks: %w", err)
+	}
+
+	var result []*LockLease
+	now := time.Now().UnixNano()
+
+	for _, data := range all {
+		var lease LockLease
+		if err := json.Unmarshal(data, &lease); err != nil {
+			continue // Skip corrupted entries.
+		}
+		if lease.ExpiresAt < now {
+			continue // Skip expired leases.
+		}
+		if volumeID != "" && lease.VolumeID != volumeID {
+			continue // Filter by volume.
+		}
+		result = append(result, &lease)
+	}
+
+	return result, nil
+}
+
+// CleanupExpiredLocks removes expired lock leases. Should be called periodically.
+func (s *RaftStore) CleanupExpiredLocks(ctx context.Context) (int, error) {
+	all, err := s.fsm.GetAll(bucketLocks)
+	if err != nil {
+		return 0, fmt.Errorf("listing locks: %w", err)
+	}
+
+	now := time.Now().UnixNano()
+	cleaned := 0
+
+	for key, data := range all {
+		var lease LockLease
+		if err := json.Unmarshal(data, &lease); err != nil {
+			continue
+		}
+		if lease.ExpiresAt < now {
+			// Remove expired lease.
+			if err := s.apply(&fsmOp{Op: opDelete, Bucket: bucketLocks, Key: key}); err == nil {
+				_ = s.removeLockFromIndex(ctx, lease.Ino, lease.LeaseID)
+				cleaned++
+			}
+		}
+	}
+
+	return cleaned, nil
+}
+
+// getLocksForInode retrieves all locks for a given inode.
+func (s *RaftStore) getLocksForInode(ctx context.Context, ino uint64) ([]*LockLease, error) {
+	// Get the index for this inode.
+	indexData, err := s.fsm.Get(bucketLocks, lockIndexKey(ino))
+	if err != nil {
+		// No locks for this inode yet.
+		return nil, nil
+	}
+
+	var index lockIndex
+	if err := json.Unmarshal(indexData, &index); err != nil {
+		return nil, fmt.Errorf("unmarshaling lock index: %w", err)
+	}
+
+	var locks []*LockLease
+	for _, leaseID := range index.LeaseIDs {
+		leaseData, err := s.fsm.Get(bucketLocks, lockKey(leaseID))
+		if err != nil {
+			// Lease may have been deleted, skip.
+			continue
+		}
+		var lease LockLease
+		if err := json.Unmarshal(leaseData, &lease); err != nil {
+			continue
+		}
+		locks = append(locks, &lease)
+	}
+
+	return locks, nil
+}
+
+// addLockToIndex adds a lease ID to the inode's lock index.
+func (s *RaftStore) addLockToIndex(ctx context.Context, ino uint64, leaseID string) error {
+	indexData, err := s.fsm.Get(bucketLocks, lockIndexKey(ino))
+	if err != nil {
+		// No index yet, create a new one.
+		index := lockIndex{
+			Ino:      ino,
+			LeaseIDs: []string{leaseID},
+		}
+		data, err := json.Marshal(index)
+		if err != nil {
+			return fmt.Errorf("marshaling new index: %w", err)
+		}
+		return s.apply(&fsmOp{Op: opPut, Bucket: bucketLocks, Key: lockIndexKey(ino), Value: data})
+	}
+
+	var index lockIndex
+	if err := json.Unmarshal(indexData, &index); err != nil {
+		return fmt.Errorf("unmarshaling index: %w", err)
+	}
+
+	// Check for duplicates.
+	for _, existingID := range index.LeaseIDs {
+		if existingID == leaseID {
+			return nil // Already in index.
+		}
+	}
+
+	index.LeaseIDs = append(index.LeaseIDs, leaseID)
+	data, err := json.Marshal(index)
+	if err != nil {
+		return fmt.Errorf("marshaling updated index: %w", err)
+	}
+	return s.apply(&fsmOp{Op: opPut, Bucket: bucketLocks, Key: lockIndexKey(ino), Value: data})
+}
+
+// removeLockFromIndex removes a lease ID from the inode's lock index.
+func (s *RaftStore) removeLockFromIndex(ctx context.Context, ino uint64, leaseID string) error {
+	indexData, err := s.fsm.Get(bucketLocks, lockIndexKey(ino))
+	if err != nil {
+		// Index doesn't exist, nothing to do.
+		return nil
+	}
+
+	var index lockIndex
+	if err := json.Unmarshal(indexData, &index); err != nil {
+		return fmt.Errorf("unmarshaling index: %w", err)
+	}
+
+	// Filter out the lease ID.
+	newLeaseIDs := make([]string, 0, len(index.LeaseIDs))
+	found := false
+	for _, existingID := range index.LeaseIDs {
+		if existingID != leaseID {
+			newLeaseIDs = append(newLeaseIDs, existingID)
+		} else {
+			found = true
+		}
+	}
+
+	if !found {
+		return nil // Lease ID not in index.
+	}
+
+	if len(newLeaseIDs) == 0 {
+		// Remove the index entry entirely.
+		return s.apply(&fsmOp{Op: opDelete, Bucket: bucketLocks, Key: lockIndexKey(ino)})
+	}
+
+	index.LeaseIDs = newLeaseIDs
+	data, err := json.Marshal(index)
+	if err != nil {
+		return fmt.Errorf("marshaling updated index: %w", err)
+	}
+	return s.apply(&fsmOp{Op: opPut, Bucket: bucketLocks, Key: lockIndexKey(ino), Value: data})
+}
+
 // splitAndTrim splits a comma-separated list of addresses and trims whitespace.
 func splitAndTrim(s string) []string {
 	parts := strings.Split(s, ",")

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -450,6 +450,40 @@ var (
 		Name:      "bandwidth_limit_bytes",
 		Help:      "Current bandwidth limit in bytes per second",
 	})
+
+	// --------------- Lock metrics ---------------
+
+	// DistributedLockLeases is the number of active distributed lock leases.
+	DistributedLockLeases = prometheus.NewGauge(prometheus.GaugeOpts{
+		Namespace: "novastor",
+		Subsystem: "filer",
+		Name:      "distributed_lock_leases",
+		Help:      "Number of active distributed lock leases",
+	})
+
+	// LockOperationsTotal counts lock operations by type.
+	LockOperationsTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Namespace: "novastor",
+		Subsystem: "filer",
+		Name:      "lock_operations_total",
+		Help:      "Total lock operations",
+	}, []string{"operation", "result"})
+
+	// LockRenewalFailures counts lock renewal failures.
+	LockRenewalFailures = prometheus.NewCounter(prometheus.CounterOpts{
+		Namespace: "novastor",
+		Subsystem: "filer",
+		Name:      "lock_renewal_failures_total",
+		Help:      "Total lock renewal failures",
+	})
+
+	// LockLeaseExpirations counts expired lock leases.
+	LockLeaseExpirations = prometheus.NewCounter(prometheus.CounterOpts{
+		Namespace: "novastor",
+		Subsystem: "filer",
+		Name:      "lock_lease_expirations_total",
+		Help:      "Total expired lock leases",
+	})
 )
 
 // Register registers all NovaStor metrics with the default Prometheus registry.
@@ -523,4 +557,10 @@ func Register() {
 	prometheus.MustRegister(DataMoverTaskDuration)
 	prometheus.MustRegister(DataMoverBytesTransferred)
 	prometheus.MustRegister(DataMoverBandwidthLimit)
+
+	// Lock metrics
+	prometheus.MustRegister(DistributedLockLeases)
+	prometheus.MustRegister(LockOperationsTotal)
+	prometheus.MustRegister(LockRenewalFailures)
+	prometheus.MustRegister(LockLeaseExpirations)
 }


### PR DESCRIPTION
## Summary

- Implemented lease-based distributed lock manager for NFS file locking coordination across multiple filer replicas
- Lock state is persisted in the metadata service (Raft-backed)
- Automatic lease renewal and expiration handling
- Fault-tolerant with lock recovery during node failures

## Changes

### New Files

- `internal/metadata/lock_meta.go` - Lock lease types, arguments, and helper functions
- `internal/metadata/lock_test.go` - Comprehensive tests for lock operations
- `internal/filer/distributed_lock.go` - DistributedLockManager with automatic renewal
- `internal/filer/distributed_lock_test.go` - Tests for the distributed lock manager

### Modified Files

- `internal/metadata/fsm.go` - Added bucketLocks constant
- `internal/metadata/store.go` - Added lock operations (AcquireLock, RenewLock, ReleaseLock, TestLock, GetLock, ListLocks, CleanupExpiredLocks)
- `internal/metadata/grpc_server.go` - Added gRPC handlers for lock operations
- `internal/metadata/grpc_client.go` - Added gRPC client methods for lock operations
- `internal/metrics/metrics.go` - Added Prometheus metrics for distributed locks

## Test plan

- [x] Unit tests for lock operations (acquire, renew, release, test, cleanup)
- [x] Tests for conflict detection (read-read, read-write, write-write)
- [x] Tests for lease expiration
- [x] Tests for same-owner no-conflict behavior
- [x] Tests for distributed lock manager (acquire, conflict, unlock, release all, cleanup, concurrent)
- [x] Integration with existing filer lock manager (compatible interface)

## Breaking changes

None. The new distributed lock system is a separate implementation. The existing in-memory LockManager remains unchanged.

Resolves #10