### PR TITLE
[Fix] Integrate Prometheus metrics in webhook server

### DIFF
--- a/cmd/webhook/main.go
+++ b/cmd/webhook/main.go
@@ -11,12 +11,14 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"go.uber.org/zap"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 
 	"github.com/piwi3910/novastor/internal/logging"
+	"github.com/piwi3910/novastor/internal/metrics"
 	"github.com/piwi3910/novastor/internal/webhook"
 )
 
@@ -53,6 +55,9 @@ func main() {
 	// Initialize logging.
 	logging.Init(false)
 	logger := logging.L.Named("webhook")
+
+	// Register Prometheus metrics.
+	metrics.Register()
 
 	logger.Info("starting novastor-webhook", zap.String("version", version), zap.String("commit", commit), zap.String("date", date))
 
@@ -139,12 +144,7 @@ func createRouter(injector *webhook.SchedulerInjector) *http.ServeMux {
 func startMetricsServer(addr string) {
 	logger := logging.L.Named("metrics")
 	mux := http.NewServeMux()
-	mux.HandleFunc("/metrics", func(w http.ResponseWriter, r *http.Request) {
-		// For now, return a simple metrics response.
-		// TODO: Integrate with prometheus/client_golang.
-		w.Header().Set("Content-Type", "text/plain")
-		w.WriteHeader(http.StatusOK)
-	})
+	mux.Handle("/metrics", promhttp.Handler())
 
 	server := &http.Server{
 		Addr:         addr,

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -246,6 +246,41 @@ var (
 		Name:      "active_locks",
 		Help:      "Number of active file locks",
 	})
+
+	// --------------- Webhook metrics ---------------
+
+	// WebhookAdmissionReviewsTotal counts admission review requests received.
+	WebhookAdmissionReviewsTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Namespace: "novastor",
+		Subsystem: "webhook",
+		Name:      "admission_reviews_total",
+		Help:      "Total admission review requests received",
+	}, []string{"operation", "resource"})
+
+	// WebhookAdmissionReviewDuration tracks admission review processing duration.
+	WebhookAdmissionReviewDuration = prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		Namespace: "novastor",
+		Subsystem: "webhook",
+		Name:      "admission_review_duration_seconds",
+		Help:      "Admission review processing duration",
+		Buckets:   []float64{0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1},
+	}, []string{"operation", "resource"})
+
+	// WebhookMutationsTotal counts mutation operations performed.
+	WebhookMutationsTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Namespace: "novastor",
+		Subsystem: "webhook",
+		Name:      "mutations_total",
+		Help:      "Total mutation operations performed",
+	}, []string{"resource", "mutation_type"})
+
+	// WebhookErrorsTotal counts webhook errors.
+	WebhookErrorsTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Namespace: "novastor",
+		Subsystem: "webhook",
+		Name:      "errors_total",
+		Help:      "Total webhook errors",
+	}, []string{"operation", "error_type"})
 )
 
 // Register registers all NovaStor metrics with the default Prometheus registry.
@@ -289,4 +324,10 @@ func Register() {
 	prometheus.MustRegister(NFSOpsTotal)
 	prometheus.MustRegister(NFSOpDuration)
 	prometheus.MustRegister(ActiveLocks)
+
+	// Webhook metrics
+	prometheus.MustRegister(WebhookAdmissionReviewsTotal)
+	prometheus.MustRegister(WebhookAdmissionReviewDuration)
+	prometheus.MustRegister(WebhookMutationsTotal)
+	prometheus.MustRegister(WebhookErrorsTotal)
 }

--- a/internal/webhook/scheduler_injector.go
+++ b/internal/webhook/scheduler_injector.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"strings"
+	"time"
 
 	"go.uber.org/zap"
 	admissionv1 "k8s.io/api/admission/v1"
@@ -15,6 +16,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 
 	"github.com/piwi3910/novastor/internal/logging"
+	"github.com/piwi3910/novastor/internal/metrics"
 )
 
 const (
@@ -156,6 +158,8 @@ func (si *SchedulerInjector) usesNovaStorPVCs(ctx context.Context, pod *corev1.P
 
 // ServeHTTP implements the http.Handler interface for the webhook.
 func (si *SchedulerInjector) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	start := time.Now()
+
 	if r.Method != http.MethodPost {
 		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
 		return
@@ -164,30 +168,46 @@ func (si *SchedulerInjector) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	var admissionReview admissionv1.AdmissionReview
 	if err := json.NewDecoder(r.Body).Decode(&admissionReview); err != nil {
 		http.Error(w, fmt.Sprintf("failed to decode request: %v", err), http.StatusBadRequest)
+		metrics.WebhookErrorsTotal.WithLabelValues("decode", "bad_request").Inc()
 		return
 	}
 
 	// Validate that we have a request.
 	if admissionReview.Request == nil {
 		http.Error(w, "nil request", http.StatusBadRequest)
+		metrics.WebhookErrorsTotal.WithLabelValues("validate", "nil_request").Inc()
 		return
 	}
+
+	// Extract labels for metrics.
+	operation := string(admissionReview.Request.Operation)
+	resource := admissionReview.Request.Kind.Kind
 
 	// Only handle CREATE operations on pods.
 	if admissionReview.Request.Kind.Kind != "Pod" || admissionReview.Request.Operation != admissionv1.Create {
 		http.Error(w, "expected CREATE operation on Pod", http.StatusBadRequest)
+		metrics.WebhookErrorsTotal.WithLabelValues(operation, "invalid_resource").Inc()
 		return
 	}
+
+	// Record admission review received.
+	metrics.WebhookAdmissionReviewsTotal.WithLabelValues(operation, resource).Inc()
 
 	// Perform the injection.
 	ctx := r.Context()
 	patch, err := si.Inject(ctx, &admissionReview)
+
+	// Record duration.
+	duration := time.Since(start).Seconds()
+	metrics.WebhookAdmissionReviewDuration.WithLabelValues(operation, resource).Observe(duration)
+
 	if err != nil {
 		logging.L.Error("failed to inject scheduler",
 			zap.Error(err),
 			zap.String("namespace", admissionReview.Request.Namespace),
 			zap.String("pod", admissionReview.Request.Name),
 		)
+		metrics.WebhookErrorsTotal.WithLabelValues(operation, "injection_failed").Inc()
 		// Return a failure response.
 		response := &admissionv1.AdmissionResponse{
 			UID:     admissionReview.Request.UID,
@@ -209,17 +229,24 @@ func (si *SchedulerInjector) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			}(),
 		}
 		admissionReview.Response = response
+
+		// Record mutation if patch was applied.
+		if len(patch) > 0 {
+			metrics.WebhookMutationsTotal.WithLabelValues(resource, "scheduler_injection").Inc()
+		}
 	}
 
 	responseJSON, err := json.Marshal(admissionReview)
 	if err != nil {
 		http.Error(w, fmt.Sprintf("failed to marshal response: %v", err), http.StatusInternalServerError)
+		metrics.WebhookErrorsTotal.WithLabelValues(operation, "marshal_response").Inc()
 		return
 	}
 
 	w.Header().Set("Content-Type", "application/json")
 	if _, err := w.Write(responseJSON); err != nil {
 		logging.L.Error("failed to write response", zap.Error(err))
+		metrics.WebhookErrorsTotal.WithLabelValues(operation, "write_response").Inc()
 	}
 }
 


### PR DESCRIPTION
## Summary
- Adds webhook-specific Prometheus metrics for observability
- Replaces stub /metrics handler with proper promhttp.Handler()
- Instruments ServeHTTP with metrics tracking

## Changes

### internal/metrics/metrics.go
Added 4 new webhook metrics:
- `novastor_webhook_admission_reviews_total` - counts admission reviews by operation/resource
- `novastor_webhook_admission_review_duration_seconds` - tracks processing duration
- `novastor_webhook_mutations_total` - counts mutations performed by type
- `novastor_webhook_errors_total` - counts errors by type

### cmd/webhook/main.go
- Import promhttp and metrics package
- Call metrics.Register() on startup
- Replace stub /metrics handler with promhttp.Handler()

### internal/webhook/scheduler_injector.go
- Add metrics instrumentation to ServeHTTP
- Track admission review counts and duration
- Track mutations (scheduler_injection) and errors

## Testing
- All webhook tests pass
- Build succeeds

Fixes #71