### PR TITLE
[Fix] Wire ReplicationManager and ErasureCoder into CSI CreateVolume

### DIFF
--- a/internal/csi/controller.go
+++ b/internal/csi/controller.go
@@ -3,6 +3,7 @@ package csi
 import (
 	"context"
 	"fmt"
+	"strconv"
 	"time"
 
 	"github.com/container-storage-interface/spec/lib/go/csi"
@@ -22,6 +23,14 @@ const (
 
 	// defaultVolumeSize is the fallback volume size when none is requested.
 	defaultVolumeSize uint64 = 1 * 1024 * 1024 * 1024 // 1 GiB
+
+	// StorageClass parameter keys.
+	paramReplicas    = "replicas"
+	paramDataShards  = "dataShards"
+	paramParityShards = "parityShards"
+
+	// Default protection settings.
+	defaultReplicas = 1
 )
 
 // MetadataStore is the subset of the metadata service used by the controller.
@@ -97,6 +106,86 @@ func hasRWXCapability(caps []*csi.VolumeCapability) bool {
 	return false
 }
 
+// protectionConfig holds parsed protection parameters from StorageClass.
+type protectionConfig struct {
+	replicas     int
+	dataShards   int
+	parityShards int
+}
+
+// parseProtectionParams extracts protection parameters from StorageClass parameters.
+// Returns default configuration (1 replica, no erasure coding) if no parameters are specified.
+func parseProtectionParams(params map[string]string) protectionConfig {
+	cfg := protectionConfig{
+		replicas: defaultReplicas,
+	}
+
+	if params == nil {
+		return cfg
+	}
+
+	if v, ok := params[paramReplicas]; ok {
+		if r, err := strconv.Atoi(v); err == nil && r > 0 {
+			cfg.replicas = r
+		}
+	}
+
+	if v, ok := params[paramDataShards]; ok {
+		if d, err := strconv.Atoi(v); err == nil && d > 0 {
+			cfg.dataShards = d
+		}
+	}
+
+	if v, ok := params[paramParityShards]; ok {
+		if p, err := strconv.Atoi(v); err == nil && p > 0 {
+			cfg.parityShards = p
+		}
+	}
+
+	return cfg
+}
+
+// toProtectionProfile converts protectionConfig to metadata.ProtectionProfile.
+// Returns nil if using default (1 replica, no EC).
+func (cfg protectionConfig) toProtectionProfile() *metadata.ProtectionProfile {
+	// Default case: single replica, no protection profile needed.
+	if cfg.replicas <= 1 && cfg.dataShards == 0 {
+		return nil
+	}
+
+	profile := &metadata.ProtectionProfile{}
+
+	if cfg.dataShards > 0 && cfg.parityShards > 0 {
+		// Erasure coding mode.
+		profile.Mode = metadata.ProtectionModeErasureCoding
+		profile.ErasureCoding = &metadata.ErasureCodingProfile{
+			DataShards:   cfg.dataShards,
+			ParityShards: cfg.parityShards,
+		}
+	} else if cfg.replicas > 1 {
+		// Replication mode.
+		profile.Mode = metadata.ProtectionModeReplication
+		profile.Replication = &metadata.ReplicationProfile{
+			Factor:      cfg.replicas,
+			WriteQuorum: cfg.replicas/2 + 1, // Majority quorum.
+		}
+	}
+
+	return profile
+}
+
+// requiredNodes returns the number of nodes needed for the protection scheme.
+func (cfg protectionConfig) requiredNodes() int {
+	if cfg.dataShards > 0 && cfg.parityShards > 0 {
+		// Erasure coding: need data + parity shards.
+		return cfg.dataShards + cfg.parityShards
+	}
+	if cfg.replicas > 0 {
+		return cfg.replicas
+	}
+	return 1
+}
+
 // CreateVolume provisions a new volume by computing chunks and persisting metadata.
 func (cs *ControllerServer) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequest) (*csi.CreateVolumeResponse, error) {
 	start := time.Now()
@@ -107,6 +196,9 @@ func (cs *ControllerServer) CreateVolume(ctx context.Context, req *csi.CreateVol
 	if req.GetName() == "" {
 		return nil, status.Error(codes.InvalidArgument, "volume name is required")
 	}
+
+	// Parse protection parameters from StorageClass.
+	protCfg := parseProtectionParams(req.GetParameters())
 
 	// Determine requested capacity.
 	requiredBytes := defaultVolumeSize
@@ -119,10 +211,19 @@ func (cs *ControllerServer) CreateVolume(ctx context.Context, req *csi.CreateVol
 	// Calculate chunk count (round up).
 	chunkCount := int((requiredBytes + chunkSize - 1) / chunkSize)
 
+	// Calculate how many nodes we need for placement.
+	// For replication: each chunk needs 'replicas' nodes.
+	// For erasure coding: each chunk needs dataShards + parityShards nodes.
+	nodesPerChunk := protCfg.requiredNodes()
+
 	// Place chunks across storage nodes.
-	nodeIDs := cs.placer.Place(chunkCount)
-	if len(nodeIDs) == 0 {
-		return nil, status.Error(codes.ResourceExhausted, "no storage nodes available for placement")
+	// We need chunkCount * nodesPerChunk placement slots.
+	totalSlots := chunkCount * nodesPerChunk
+	nodeIDs := cs.placer.Place(totalSlots)
+	if len(nodeIDs) < totalSlots {
+		return nil, status.Errorf(codes.ResourceExhausted,
+			"not enough storage nodes: need %d for %d chunks with protection factor %d, got %d",
+			totalSlots, chunkCount, nodesPerChunk, len(nodeIDs))
 	}
 
 	volumeID := uuid.New().String()
@@ -133,25 +234,36 @@ func (cs *ControllerServer) CreateVolume(ctx context.Context, req *csi.CreateVol
 	}
 
 	vm := &metadata.VolumeMeta{
-		VolumeID:  volumeID,
-		SizeBytes: requiredBytes,
-		ChunkIDs:  chunkIDs,
+		VolumeID:          volumeID,
+		SizeBytes:         requiredBytes,
+		ChunkIDs:          chunkIDs,
+		ProtectionProfile: protCfg.toProtectionProfile(),
 	}
 
-	// Write placement maps for each chunk. This is critical for recovery:
-	// if a node fails, the recovery manager uses these maps to know which
-	// chunks were on that node and need re-replication.
-	// Each chunk is placed on the node at the same index in nodeIDs.
+	// Write placement maps for each chunk with multiple nodes for protection.
+	// Each chunk is placed on 'nodesPerChunk' consecutive nodes from nodeIDs.
 	for i, chunkID := range chunkIDs {
-		if i < len(nodeIDs) {
-			pm := &metadata.PlacementMap{
-				ChunkID: chunkID,
-				Nodes:   []string{nodeIDs[i]},
-			}
-			if err := cs.meta.PutPlacementMap(ctx, pm); err != nil {
-				return nil, status.Errorf(codes.Internal, "writing placement map for chunk %s: %v", chunkID, err)
-			}
+		// Calculate the slice of nodes for this chunk.
+		startIdx := i * nodesPerChunk
+		endIdx := startIdx + nodesPerChunk
+		if endIdx > len(nodeIDs) {
+			endIdx = len(nodeIDs)
 		}
+		chunkNodes := nodeIDs[startIdx:endIdx]
+
+		pm := &metadata.PlacementMap{
+			ChunkID: chunkID,
+			Nodes:   chunkNodes,
+		}
+		if err := cs.meta.PutPlacementMap(ctx, pm); err != nil {
+			return nil, status.Errorf(codes.Internal, "writing placement map for chunk %s: %v", chunkID, err)
+		}
+
+		logging.L.Debug("placed chunk with protection",
+			zap.String("volumeID", volumeID),
+			zap.String("chunkID", chunkID),
+			zap.Strings("nodes", chunkNodes),
+			zap.Int("replicas", nodesPerChunk))
 	}
 
 	// Set volume context for RWX (NFS-backed) volumes.

--- a/internal/csi/protection_test.go
+++ b/internal/csi/protection_test.go
@@ -1,0 +1,212 @@
+package csi
+
+import (
+	"testing"
+
+	"github.com/piwi3910/novastor/internal/metadata"
+)
+
+func TestParseProtectionParams(t *testing.T) {
+	tests := []struct {
+		name       string
+		params     map[string]string
+		wantRepl   int
+		wantData   int
+		wantParity int
+	}{
+		{
+			name:       "nil params returns default",
+			params:     nil,
+			wantRepl:   1,
+			wantData:   0,
+			wantParity: 0,
+		},
+		{
+			name:       "empty params returns default",
+			params:     map[string]string{},
+			wantRepl:   1,
+			wantData:   0,
+			wantParity: 0,
+		},
+		{
+			name: "replicas parameter",
+			params: map[string]string{
+				"replicas": "3",
+			},
+			wantRepl:   3,
+			wantData:   0,
+			wantParity: 0,
+		},
+		{
+			name: "erasure coding parameters",
+			params: map[string]string{
+				"dataShards":  "4",
+				"parityShards": "2",
+			},
+			wantRepl:   1,
+			wantData:   4,
+			wantParity: 2,
+		},
+		{
+			name: "invalid replicas ignored",
+			params: map[string]string{
+				"replicas": "invalid",
+			},
+			wantRepl:   1,
+			wantData:   0,
+			wantParity: 0,
+		},
+		{
+			name: "negative replicas ignored",
+			params: map[string]string{
+				"replicas": "-1",
+			},
+			wantRepl:   1,
+			wantData:   0,
+			wantParity: 0,
+		},
+		{
+			name: "zero replicas ignored",
+			params: map[string]string{
+				"replicas": "0",
+			},
+			wantRepl:   1,
+			wantData:   0,
+			wantParity: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := parseProtectionParams(tt.params)
+			if cfg.replicas != tt.wantRepl {
+				t.Errorf("parseProtectionParams() replicas = %v, want %v", cfg.replicas, tt.wantRepl)
+			}
+			if cfg.dataShards != tt.wantData {
+				t.Errorf("parseProtectionParams() dataShards = %v, want %v", cfg.dataShards, tt.wantData)
+			}
+			if cfg.parityShards != tt.wantParity {
+				t.Errorf("parseProtectionParams() parityShards = %v, want %v", cfg.parityShards, tt.wantParity)
+			}
+		})
+	}
+}
+
+func TestProtectionConfig_toProtectionProfile(t *testing.T) {
+	tests := []struct {
+		name string
+		cfg  protectionConfig
+		want *metadata.ProtectionProfile
+	}{
+		{
+			name: "default config returns nil",
+			cfg:  protectionConfig{replicas: 1, dataShards: 0, parityShards: 0},
+			want: nil,
+		},
+		{
+			name: "replication config",
+			cfg:  protectionConfig{replicas: 3, dataShards: 0, parityShards: 0},
+			want: &metadata.ProtectionProfile{
+				Mode: metadata.ProtectionModeReplication,
+				Replication: &metadata.ReplicationProfile{
+					Factor:      3,
+					WriteQuorum: 2,
+				},
+			},
+		},
+		{
+			name: "erasure coding config",
+			cfg:  protectionConfig{replicas: 1, dataShards: 4, parityShards: 2},
+			want: &metadata.ProtectionProfile{
+				Mode: metadata.ProtectionModeErasureCoding,
+				ErasureCoding: &metadata.ErasureCodingProfile{
+					DataShards:   4,
+					ParityShards: 2,
+				},
+			},
+		},
+		{
+			name: "both EC and replication prefers EC",
+			cfg:  protectionConfig{replicas: 3, dataShards: 4, parityShards: 2},
+			want: &metadata.ProtectionProfile{
+				Mode: metadata.ProtectionModeErasureCoding,
+				ErasureCoding: &metadata.ErasureCodingProfile{
+					DataShards:   4,
+					ParityShards: 2,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.cfg.toProtectionProfile()
+			if tt.want == nil {
+				if got != nil {
+					t.Errorf("toProtectionProfile() = %v, want nil", got)
+				}
+				return
+			}
+			if got == nil {
+				t.Errorf("toProtectionProfile() = nil, want %v", tt.want)
+				return
+			}
+			if got.Mode != tt.want.Mode {
+				t.Errorf("toProtectionProfile() Mode = %v, want %v", got.Mode, tt.want.Mode)
+			}
+			if got.Replication != nil && tt.want.Replication != nil {
+				if got.Replication.Factor != tt.want.Replication.Factor {
+					t.Errorf("toProtectionProfile() Replication.Factor = %v, want %v", got.Replication.Factor, tt.want.Replication.Factor)
+				}
+				if got.Replication.WriteQuorum != tt.want.Replication.WriteQuorum {
+					t.Errorf("toProtectionProfile() Replication.WriteQuorum = %v, want %v", got.Replication.WriteQuorum, tt.want.Replication.WriteQuorum)
+				}
+			}
+			if got.ErasureCoding != nil && tt.want.ErasureCoding != nil {
+				if got.ErasureCoding.DataShards != tt.want.ErasureCoding.DataShards {
+					t.Errorf("toProtectionProfile() ErasureCoding.DataShards = %v, want %v", got.ErasureCoding.DataShards, tt.want.ErasureCoding.DataShards)
+				}
+				if got.ErasureCoding.ParityShards != tt.want.ErasureCoding.ParityShards {
+					t.Errorf("toProtectionProfile() ErasureCoding.ParityShards = %v, want %v", got.ErasureCoding.ParityShards, tt.want.ErasureCoding.ParityShards)
+				}
+			}
+		})
+	}
+}
+
+func TestProtectionConfig_requiredNodes(t *testing.T) {
+	tests := []struct {
+		name string
+		cfg  protectionConfig
+		want int
+	}{
+		{
+			name: "default single node",
+			cfg:  protectionConfig{replicas: 1, dataShards: 0, parityShards: 0},
+			want: 1,
+		},
+		{
+			name: "3-way replication",
+			cfg:  protectionConfig{replicas: 3, dataShards: 0, parityShards: 0},
+			want: 3,
+		},
+		{
+			name: "4+2 erasure coding",
+			cfg:  protectionConfig{replicas: 1, dataShards: 4, parityShards: 2},
+			want: 6,
+		},
+		{
+			name: "8+2 erasure coding",
+			cfg:  protectionConfig{replicas: 1, dataShards: 8, parityShards: 2},
+			want: 10,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.cfg.requiredNodes(); got != tt.want {
+				t.Errorf("requiredNodes() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
This PR wires the ReplicationManager and ErasureCoder into the CSI CreateVolume workflow, enabling data protection through replication or erasure coding based on StorageClass parameters.

## Changes

### CSI Controller ()
- Added StorageClass parameter parsing for:
  - `replicas`: Number of replicas (e.g., 3 for 3-way replication)
  - `dataShards`: Data shards for erasure coding
  - `parityShards`: Parity shards for erasure coding
- Added `protectionConfig` struct and helper functions:
  - `parseProtectionParams()`: Extracts protection params from StorageClass
  - `toProtectionProfile()`: Converts config to metadata.ProtectionProfile
  - `requiredNodes()`: Calculates nodes needed for protection scheme
- Updated `CreateVolume` to:
  - Parse protection parameters from StorageClass
  - Calculate required nodes based on protection scheme
  - Place each chunk on multiple nodes (replicas or shards)
  - Store ProtectionProfile in VolumeMeta
  - Update placement maps with all replica nodes

### Tests ()
- Unit tests for parameter parsing
- Unit tests for ProtectionProfile conversion
- Unit tests for required nodes calculation

## StorageClass Examples

### Replication (3-way)
```yaml
apiVersion: storage.k8s.io/v1
kind: StorageClass
metadata:
  name: novastor-replicated
provisioner: novastor.csi.novastor.io
parameters:
  replicas: 3
```

### Erasure Coding (4+2)
```yaml
apiVersion: storage.k8s.io/v1
kind: StorageClass
metadata:
  name: novastor-erasure-coded
provisioner: novastor.csi.novastor.io
parameters:
  dataShards: 4
  parityShards: 2
```

## Testing
- All existing CSI tests pass
- New protection parameter tests pass
- Build succeeds

Fixes #16, #17