### PR TITLE
[Feature] Add policy engine for compliance checking and reconciliation

### DIFF
--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -22,6 +22,7 @@ import (
 	"github.com/piwi3910/novastor/internal/logging"
 	"github.com/piwi3910/novastor/internal/metadata"
 	"github.com/piwi3910/novastor/internal/operator"
+	"github.com/piwi3910/novastor/internal/policy"
 	"github.com/piwi3910/novastor/internal/transport"
 )
 
@@ -161,6 +162,10 @@ func main() {
 	var tlsCert string
 	var tlsKey string
 	var tlsRotationInterval time.Duration
+	var policyEngineEnabled bool
+	var policyScanIntervalStr string
+	var policyRepairEnabled bool
+	var policyRepairConcurrency int
 
 	flag.StringVar(&metricsAddr, "metrics-bind-address", ":8080", "The address the metric endpoint binds to.")
 	flag.StringVar(&healthProbeAddr, "health-probe-bind-address", ":8081", "The address the health probe endpoint binds to.")
@@ -174,6 +179,10 @@ func main() {
 	flag.StringVar(&tlsCert, "tls-cert", "", "Path to client certificate for mTLS")
 	flag.StringVar(&tlsKey, "tls-key", "", "Path to client key for mTLS")
 	flag.DurationVar(&tlsRotationInterval, "tls-rotation-interval", 5*time.Minute, "Interval for TLS certificate rotation checks")
+	flag.BoolVar(&policyEngineEnabled, "policy-engine-enabled", true, "Enable policy engine for compliance checking and reconciliation.")
+	flag.StringVar(&policyScanIntervalStr, "policy-scan-interval", "5m", "Interval between compliance scans.")
+	flag.BoolVar(&policyRepairEnabled, "policy-repair-enabled", true, "Enable automatic repair of non-compliant chunks.")
+	flag.IntVar(&policyRepairConcurrency, "policy-repair-concurrency", 4, "Maximum number of concurrent policy repair operations.")
 
 	opts := crzap.Options{Development: true}
 	opts.BindFlags(flag.CommandLine)
@@ -293,6 +302,42 @@ func main() {
 			"heartbeatTimeout", heartbeatTimeout,
 			"concurrency", recoveryConcurrency,
 		)
+
+		// Set up the policy engine if enabled.
+		if policyEngineEnabled {
+			policyScanInterval, parseErr := time.ParseDuration(policyScanIntervalStr)
+			if parseErr != nil {
+				setupLog.Error(parseErr, "invalid policy-scan-interval value", "value", policyScanIntervalStr)
+				os.Exit(1)
+			}
+
+			poolLookup := policy.NewK8sPoolLookup(mgr.GetClient())
+			nodeChecker := policy.NewK8sNodeAvailabilityChecker(mgr.GetClient())
+			metaAdapter := policy.NewGRPCMetadataAdapter(metaClient)
+
+			policyRunnable := policy.NewPolicyEngineRunnable(
+				metaAdapter,
+				poolLookup,
+				nodeChecker,
+				chunkReplicator,
+				nil, // shardReplicator - TODO: implement erasure coding shard replication
+				nil, // eventRecorder - optional
+				policyScanInterval,
+				policyRepairEnabled,
+			)
+			policyRunnable.Reconciler().SetMaxConcurrent(policyRepairConcurrency)
+
+			if err := mgr.Add(policyRunnable); err != nil {
+				setupLog.Error(err, "unable to add policy engine runnable to manager")
+				os.Exit(1)
+			}
+
+			setupLog.Info("policy engine enabled",
+				"scanInterval", policyScanInterval,
+				"repairEnabled", policyRepairEnabled,
+				"concurrency", policyRepairConcurrency,
+			)
+		}
 	}
 
 	// Health and readiness probes.

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/spf13/cobra v1.10.2
 	go.uber.org/zap v1.27.1
 	golang.org/x/crypto v0.46.0
+	golang.org/x/sync v0.19.0
 	golang.org/x/sys v0.39.0
 	google.golang.org/grpc v1.72.2
 	google.golang.org/protobuf v1.36.8
@@ -79,7 +80,6 @@ require (
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	golang.org/x/net v0.48.0 // indirect
 	golang.org/x/oauth2 v0.30.0 // indirect
-	golang.org/x/sync v0.19.0 // indirect
 	golang.org/x/term v0.38.0 // indirect
 	golang.org/x/text v0.32.0 // indirect
 	golang.org/x/time v0.9.0 // indirect

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -130,6 +130,75 @@ var (
 		Help:      "Chunks recovered",
 	})
 
+	// RecoveryFailed counts the total number of chunk recovery failures.
+	RecoveryFailed = prometheus.NewCounter(prometheus.CounterOpts{
+		Namespace: "novastor",
+		Subsystem: "controller",
+		Name:      "recovery_chunks_failed_total",
+		Help:      "Chunk recovery failures",
+	})
+
+	// --------------- Policy Engine metrics ---------------
+
+	// ComplianceStatus reports the compliance status of each storage pool.
+	// Status values: 1=compliant, 0=non_compliant
+	PoolComplianceStatus = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: "novastor",
+		Subsystem: "policy",
+		Name:      "pool_compliance_status",
+		Help:      "Compliance status of storage pool (1=compliant, 0=non_compliant)",
+	}, []string{"pool", "mode"})
+
+	// ChunkComplianceViolations counts chunks by compliance status per pool.
+	ChunkComplianceViolations = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: "novastor",
+		Subsystem: "policy",
+		Name:      "chunk_compliance_violations",
+		Help:      "Number of chunks with compliance violations",
+	}, []string{"pool", "status"})
+
+	// PolicyScanDuration tracks the time taken for compliance scans.
+	PolicyScanDuration = prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		Namespace: "novastor",
+		Subsystem: "policy",
+		Name:      "scan_duration_seconds",
+		Help:      "Compliance scan duration",
+		Buckets:   prometheus.DefBuckets,
+	}, []string{"scope"})
+
+	// PolicyRepairQueued tracks the number of chunks queued for repair.
+	PolicyRepairQueued = prometheus.NewGauge(prometheus.GaugeOpts{
+		Namespace: "novastor",
+		Subsystem: "policy",
+		Name:      "repair_queued",
+		Help:      "Chunks queued for repair",
+	})
+
+	// PolicyRepairCompleted counts the total number of chunk repairs completed.
+	PolicyRepairCompleted = prometheus.NewCounter(prometheus.CounterOpts{
+		Namespace: "novastor",
+		Subsystem: "policy",
+		Name:      "repair_completed_total",
+		Help:      "Chunk repairs completed",
+	})
+
+	// PolicyRepairFailed counts the total number of chunk repair failures.
+	PolicyRepairFailed = prometheus.NewCounter(prometheus.CounterOpts{
+		Namespace: "novastor",
+		Subsystem: "policy",
+		Name:      "repair_failed_total",
+		Help:      "Chunk repair failures",
+	})
+
+	// PolicyRepairDuration tracks the time taken for repair operations.
+	PolicyRepairDuration = prometheus.NewHistogram(prometheus.HistogramOpts{
+		Namespace: "novastor",
+		Subsystem: "policy",
+		Name:      "repair_duration_seconds",
+		Help:      "Time to complete chunk repair",
+		Buckets:   prometheus.DefBuckets,
+	})
+
 	// --------------- CSI metrics ---------------
 
 	// VolumeCount is the number of currently provisioned volumes.
@@ -305,6 +374,16 @@ func Register() {
 	prometheus.MustRegister(PoolCapacityBytes)
 	prometheus.MustRegister(RecoveryPending)
 	prometheus.MustRegister(RecoveryCompleted)
+	prometheus.MustRegister(RecoveryFailed)
+
+	// Policy Engine metrics
+	prometheus.MustRegister(PoolComplianceStatus)
+	prometheus.MustRegister(ChunkComplianceViolations)
+	prometheus.MustRegister(PolicyScanDuration)
+	prometheus.MustRegister(PolicyRepairQueued)
+	prometheus.MustRegister(PolicyRepairCompleted)
+	prometheus.MustRegister(PolicyRepairFailed)
+	prometheus.MustRegister(PolicyRepairDuration)
 
 	// CSI metrics
 	prometheus.MustRegister(VolumeCount)

--- a/internal/policy/adapter.go
+++ b/internal/policy/adapter.go
@@ -1,0 +1,103 @@
+package policy
+
+import (
+	"context"
+
+	"github.com/piwi3910/novastor/internal/metadata"
+)
+
+// GRPCMetadataAdapter wraps a metadata.GRPCClient to implement MetadataClient.
+// It converts between the policy package types and the metadata package types.
+type GRPCMetadataAdapter struct {
+	client *metadata.GRPCClient
+}
+
+// NewGRPCMetadataAdapter creates a new GRPCMetadataAdapter.
+func NewGRPCMetadataAdapter(client *metadata.GRPCClient) *GRPCMetadataAdapter {
+	return &GRPCMetadataAdapter{client: client}
+}
+
+// GetPlacementMap implements MetadataClient.
+func (a *GRPCMetadataAdapter) GetPlacementMap(ctx context.Context, chunkID string) (*PlacementMap, error) {
+	pm, err := a.client.GetPlacementMap(ctx, chunkID)
+	if err != nil {
+		return nil, err
+	}
+	return &PlacementMap{
+		ChunkID: pm.ChunkID,
+		Nodes:   pm.Nodes,
+	}, nil
+}
+
+// PutPlacementMap implements MetadataClient.
+func (a *GRPCMetadataAdapter) PutPlacementMap(ctx context.Context, pm *PlacementMap) error {
+	return a.client.PutPlacementMap(ctx, &metadata.PlacementMap{
+		ChunkID: pm.ChunkID,
+		Nodes:   pm.Nodes,
+	})
+}
+
+// ListPlacementMaps implements MetadataClient.
+func (a *GRPCMetadataAdapter) ListPlacementMaps(ctx context.Context) ([]*PlacementMap, error) {
+	pms, err := a.client.ListPlacementMaps(ctx)
+	if err != nil {
+		return nil, err
+	}
+	result := make([]*PlacementMap, len(pms))
+	for i, pm := range pms {
+		result[i] = &PlacementMap{
+			ChunkID: pm.ChunkID,
+			Nodes:   pm.Nodes,
+		}
+	}
+	return result, nil
+}
+
+// ListNodeMetas implements MetadataClient.
+func (a *GRPCMetadataAdapter) ListNodeMetas(ctx context.Context) ([]*NodeMeta, error) {
+	nodes, err := a.client.ListNodeMetas(ctx)
+	if err != nil {
+		return nil, err
+	}
+	result := make([]*NodeMeta, len(nodes))
+	for i, n := range nodes {
+		result[i] = &NodeMeta{
+			NodeID:        n.NodeID,
+			Address:       n.Address,
+			LastHeartbeat: n.LastHeartbeat,
+		}
+	}
+	return result, nil
+}
+
+// GetVolumeMeta implements MetadataClient.
+func (a *GRPCMetadataAdapter) GetVolumeMeta(ctx context.Context, volumeID string) (*VolumeMeta, error) {
+	vol, err := a.client.GetVolumeMeta(ctx, volumeID)
+	if err != nil {
+		return nil, err
+	}
+	return &VolumeMeta{
+		VolumeID:  vol.VolumeID,
+		Pool:      vol.Pool,
+		SizeBytes: vol.SizeBytes,
+		ChunkIDs:  vol.ChunkIDs,
+	}, nil
+}
+
+// ListVolumesMeta implements MetadataClient.
+func (a *GRPCMetadataAdapter) ListVolumesMeta(ctx context.Context) ([]*VolumeMeta, error) {
+	vols, err := a.client.ListVolumesMeta(ctx)
+	if err != nil {
+		return nil, err
+	}
+	result := make([]*VolumeMeta, len(vols))
+	for i, v := range vols {
+		result[i] = &VolumeMeta{
+			VolumeID:  v.VolumeID,
+			Pool:      v.Pool,
+			SizeBytes: v.SizeBytes,
+			ChunkIDs:  v.ChunkIDs,
+		}
+	}
+	return result, nil
+}

--- a/internal/policy/compliance.go
+++ b/internal/policy/compliance.go
@@ -1,0 +1,235 @@
+package policy
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/piwi3910/novastor/api/v1alpha1"
+)
+
+// ComplianceStatus represents the compliance state of a chunk.
+type ComplianceStatus int
+
+const (
+	// StatusCompliant indicates the chunk meets all data protection requirements.
+	StatusCompliant ComplianceStatus = iota
+	// StatusUnderReplicated indicates the chunk has fewer replicas/shards than required.
+	StatusUnderReplicated
+	// StatusUnavailable indicates the chunk has no available replicas.
+	StatusUnavailable
+	// StatusCorrupted indicates the chunk has checksum mismatches.
+	StatusCorrupted
+)
+
+// String returns a human-readable representation of the compliance status.
+func (s ComplianceStatus) String() string {
+	switch s {
+	case StatusCompliant:
+		return "compliant"
+	case StatusUnderReplicated:
+		return "under_replicated"
+	case StatusUnavailable:
+		return "unavailable"
+	case StatusCorrupted:
+		return "corrupted"
+	default:
+		return "unknown"
+	}
+}
+
+// ChunkComplianceResult contains the compliance state and metadata for a single chunk.
+type ChunkComplianceResult struct {
+	ChunkID        string           `json:"chunkID"`
+	Status         ComplianceStatus `json:"status"`
+	ExpectedCount  int              `json:"expectedCount"`
+	ActualCount    int              `json:"actualCount"`
+	AvailableNodes []string         `json:"availableNodes"`
+	FailedNodes    []string         `json:"failedNodes,omitempty"`
+	VolumeID       string           `json:"volumeID"`
+	Pool           string           `json:"pool"`
+	ProtectionMode string           `json:"protectionMode"`
+}
+
+// VolumeComplianceReport contains the compliance summary for a single volume.
+type VolumeComplianceReport struct {
+	VolumeID              string                   `json:"volumeID"`
+	Pool                  string                   `json:"pool"`
+	TotalChunks           int                      `json:"totalChunks"`
+	CompliantChunks       int                      `json:"compliantChunks"`
+	UnderReplicatedChunks int                      `json:"underReplicatedChunks"`
+	UnavailableChunks     int                      `json:"unavailableChunks"`
+	CorruptedChunks       int                      `json:"corruptedChunks"`
+	ChunkResults          []*ChunkComplianceResult `json:"chunkResults,omitempty"`
+}
+
+// PoolComplianceReport contains the compliance summary for a storage pool.
+type PoolComplianceReport struct {
+	PoolName              string                    `json:"poolName"`
+	ProtectionMode        string                    `json:"protectionMode"`
+	ReplicationFactor     int                       `json:"replicationFactor,omitempty"`
+	DataShards            int                       `json:"dataShards,omitempty"`
+	ParityShards          int                       `json:"parityShards,omitempty"`
+	TotalVolumes          int                       `json:"totalVolumes"`
+	TotalChunks           int                       `json:"totalChunks"`
+	CompliantChunks       int                       `json:"compliantChunks"`
+	UnderReplicatedChunks int                       `json:"underReplicatedChunks"`
+	UnavailableChunks     int                       `json:"unavailableChunks"`
+	CorruptedChunks       int                       `json:"corruptedChunks"`
+	IsCompliant           bool                      `json:"isCompliant"`
+	VolumeReports         []*VolumeComplianceReport `json:"volumeReports,omitempty"`
+}
+
+// ComplianceChecker defines the interface for checking chunk compliance.
+type ComplianceChecker interface {
+	// CheckChunk verifies if a chunk meets the data protection requirements.
+	CheckChunk(ctx context.Context, chunkID string, volume *VolumeMeta, pool *v1alpha1.StoragePool) (*ChunkComplianceResult, error)
+	// RequiredReplicas returns the number of replicas required for compliance.
+	RequiredReplicas() int
+}
+
+// NodeAvailabilityChecker checks if a node is available.
+type NodeAvailabilityChecker interface {
+	IsNodeAvailable(ctx context.Context, nodeID string) bool
+}
+
+// PolicyEngine coordinates compliance checking across all volumes and pools.
+type PolicyEngine struct {
+	metaClient         MetadataClient
+	nodeChecker        NodeAvailabilityChecker
+	replicationChecker *ReplicationChecker
+	erasureChecker     *ErasureCodingChecker
+}
+
+// NewPolicyEngine creates a new PolicyEngine with the given dependencies.
+func NewPolicyEngine(metaClient MetadataClient, nodeChecker NodeAvailabilityChecker) *PolicyEngine {
+	return &PolicyEngine{
+		metaClient:         metaClient,
+		nodeChecker:        nodeChecker,
+		replicationChecker: NewReplicationChecker(metaClient, nodeChecker),
+		erasureChecker:     NewErasureCodingChecker(metaClient, nodeChecker),
+	}
+}
+
+// GetChecker returns the appropriate compliance checker for the given pool.
+func (e *PolicyEngine) GetChecker(pool *v1alpha1.StoragePool) (ComplianceChecker, error) {
+	switch pool.Spec.DataProtection.Mode {
+	case "replication":
+		return e.replicationChecker, nil
+	case "erasureCoding":
+		return e.erasureChecker, nil
+	default:
+		return nil, fmt.Errorf("unknown data protection mode: %s", pool.Spec.DataProtection.Mode)
+	}
+}
+
+// CheckVolumeCompliance generates a compliance report for a single volume.
+func (e *PolicyEngine) CheckVolumeCompliance(ctx context.Context, volume *VolumeMeta, pool *v1alpha1.StoragePool) (*VolumeComplianceReport, error) {
+	report := &VolumeComplianceReport{
+		VolumeID: volume.VolumeID,
+		Pool:     volume.Pool,
+	}
+
+	checker, err := e.GetChecker(pool)
+	if err != nil {
+		return nil, fmt.Errorf("getting compliance checker for volume %s: %w", volume.VolumeID, err)
+	}
+
+	for _, chunkID := range volume.ChunkIDs {
+		result, err := checker.CheckChunk(ctx, chunkID, volume, pool)
+		if err != nil {
+			return nil, fmt.Errorf("checking chunk %s: %w", chunkID, err)
+		}
+
+		report.TotalChunks++
+		switch result.Status {
+		case StatusCompliant:
+			report.CompliantChunks++
+		case StatusUnderReplicated:
+			report.UnderReplicatedChunks++
+		case StatusUnavailable:
+			report.UnavailableChunks++
+		case StatusCorrupted:
+			report.CorruptedChunks++
+		}
+		report.ChunkResults = append(report.ChunkResults, result)
+	}
+
+	return report, nil
+}
+
+// CheckPoolCompliance generates a compliance report for a storage pool.
+func (e *PolicyEngine) CheckPoolCompliance(ctx context.Context, pool *v1alpha1.StoragePool) (*PoolComplianceReport, error) {
+	report := &PoolComplianceReport{
+		PoolName:       pool.Name,
+		ProtectionMode: pool.Spec.DataProtection.Mode,
+	}
+
+	switch pool.Spec.DataProtection.Mode {
+	case "replication":
+		if pool.Spec.DataProtection.Replication != nil {
+			report.ReplicationFactor = pool.Spec.DataProtection.Replication.Factor
+		}
+	case "erasureCoding":
+		if pool.Spec.DataProtection.ErasureCoding != nil {
+			report.DataShards = pool.Spec.DataProtection.ErasureCoding.DataShards
+			report.ParityShards = pool.Spec.DataProtection.ErasureCoding.ParityShards
+		}
+	}
+
+	volumes, err := e.metaClient.ListVolumesMeta(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("listing volumes: %w", err)
+	}
+
+	for _, volume := range volumes {
+		if volume.Pool != pool.Name {
+			continue
+		}
+		report.TotalVolumes++
+
+		volumeReport, err := e.CheckVolumeCompliance(ctx, volume, pool)
+		if err != nil {
+			return nil, fmt.Errorf("checking volume %s: %w", volume.VolumeID, err)
+		}
+
+		report.TotalChunks += volumeReport.TotalChunks
+		report.CompliantChunks += volumeReport.CompliantChunks
+		report.UnderReplicatedChunks += volumeReport.UnderReplicatedChunks
+		report.UnavailableChunks += volumeReport.UnavailableChunks
+		report.CorruptedChunks += volumeReport.CorruptedChunks
+		report.VolumeReports = append(report.VolumeReports, volumeReport)
+	}
+
+	// Pool is compliant if all chunks are compliant and there are no unavailable chunks.
+	report.IsCompliant = report.UnderReplicatedChunks == 0 &&
+		report.UnavailableChunks == 0 &&
+		report.CorruptedChunks == 0
+
+	return report, nil
+}
+
+// CheckAllPoolsCompliance generates compliance reports for all storage pools.
+// It fetches pools from Kubernetes API via the poolLookup.
+func (e *PolicyEngine) CheckAllPoolsCompliance(ctx context.Context, poolLookup PoolLookup) (map[string]*PoolComplianceReport, error) {
+	pools, err := poolLookup.ListPools(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("listing pools: %w", err)
+	}
+
+	reports := make(map[string]*PoolComplianceReport)
+	for _, pool := range pools {
+		report, err := e.CheckPoolCompliance(ctx, pool)
+		if err != nil {
+			return nil, fmt.Errorf("checking pool %s: %w", pool.Name, err)
+		}
+		reports[pool.Name] = report
+	}
+
+	return reports, nil
+}
+
+// PoolLookup retrieves storage pool configurations.
+type PoolLookup interface {
+	ListPools(ctx context.Context) ([]*v1alpha1.StoragePool, error)
+	GetPool(ctx context.Context, name string) (*v1alpha1.StoragePool, error)
+}

--- a/internal/policy/compliance_test.go
+++ b/internal/policy/compliance_test.go
@@ -1,0 +1,570 @@
+package policy
+
+import (
+	"context"
+	"testing"
+
+	"github.com/piwi3910/novastor/api/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// mockNodeChecker is a test double for NodeAvailabilityChecker.
+type mockNodeChecker struct {
+	availableNodes map[string]bool
+}
+
+func (m *mockNodeChecker) IsNodeAvailable(_ context.Context, nodeID string) bool {
+	if m.availableNodes == nil {
+		return true
+	}
+	return m.availableNodes[nodeID]
+}
+
+// mockMetadataClient is a test double for metadata.GRPCClient.
+type mockMetadataClient struct {
+	volumes       map[string]*VolumeMeta
+	placementMaps map[string]*PlacementMap
+}
+
+func (m *mockMetadataClient) GetVolumeMeta(_ context.Context, volumeID string) (*VolumeMeta, error) {
+	if m.volumes == nil {
+		return nil, nil
+	}
+	return m.volumes[volumeID], nil
+}
+
+func (m *mockMetadataClient) ListVolumesMeta(_ context.Context) ([]*VolumeMeta, error) {
+	if m.volumes == nil {
+		return nil, nil
+	}
+	var result []*VolumeMeta
+	for _, v := range m.volumes {
+		result = append(result, v)
+	}
+	return result, nil
+}
+
+func (m *mockMetadataClient) GetPlacementMap(_ context.Context, chunkID string) (*PlacementMap, error) {
+	if m.placementMaps == nil {
+		return nil, nil
+	}
+	return m.placementMaps[chunkID], nil
+}
+
+func (m *mockMetadataClient) PutPlacementMap(_ context.Context, pm *PlacementMap) error {
+	if m.placementMaps == nil {
+		m.placementMaps = make(map[string]*PlacementMap)
+	}
+	m.placementMaps[pm.ChunkID] = pm
+	return nil
+}
+
+func (m *mockMetadataClient) ListPlacementMaps(_ context.Context) ([]*PlacementMap, error) {
+	if m.placementMaps == nil {
+		return nil, nil
+	}
+	var result []*PlacementMap
+	for _, pm := range m.placementMaps {
+		result = append(result, pm)
+	}
+	return result, nil
+}
+
+func (m *mockMetadataClient) ListNodeMetas(_ context.Context) ([]*NodeMeta, error) {
+	// Return empty list for now
+	return []*NodeMeta{}, nil
+}
+
+// mockPoolLookup is a test double for PoolLookup.
+type mockPoolLookup struct {
+	pools map[string]*v1alpha1.StoragePool
+}
+
+func (m *mockPoolLookup) ListPools(_ context.Context) ([]*v1alpha1.StoragePool, error) {
+	if m.pools == nil {
+		return nil, nil
+	}
+	var result []*v1alpha1.StoragePool
+	for _, p := range m.pools {
+		result = append(result, p)
+	}
+	return result, nil
+}
+
+func (m *mockPoolLookup) GetPool(_ context.Context, name string) (*v1alpha1.StoragePool, error) {
+	if m.pools == nil {
+		return nil, nil
+	}
+	return m.pools[name], nil
+}
+
+func TestReplicationChecker_CheckChunk(t *testing.T) {
+	tests := []struct {
+		name           string
+		pool           *v1alpha1.StoragePool
+		placement      *PlacementMap
+		availableNodes map[string]bool
+		wantStatus     ComplianceStatus
+		wantAvailable  int
+		wantFailed     int
+	}{
+		{
+			name: "fully compliant - all replicas available",
+			pool: &v1alpha1.StoragePool{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-pool"},
+				Spec: v1alpha1.StoragePoolSpec{
+					DataProtection: v1alpha1.DataProtectionSpec{
+						Mode: "replication",
+						Replication: &v1alpha1.ReplicationSpec{
+							Factor: 3,
+						},
+					},
+				},
+			},
+			placement: &PlacementMap{
+				ChunkID: "chunk1",
+				Nodes:   []string{"node1", "node2", "node3"},
+			},
+			availableNodes: map[string]bool{
+				"node1": true,
+				"node2": true,
+				"node3": true,
+			},
+			wantStatus:    StatusCompliant,
+			wantAvailable: 3,
+			wantFailed:    0,
+		},
+		{
+			name: "under replicated - one replica down",
+			pool: &v1alpha1.StoragePool{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-pool"},
+				Spec: v1alpha1.StoragePoolSpec{
+					DataProtection: v1alpha1.DataProtectionSpec{
+						Mode: "replication",
+						Replication: &v1alpha1.ReplicationSpec{
+							Factor: 3,
+						},
+					},
+				},
+			},
+			placement: &PlacementMap{
+				ChunkID: "chunk1",
+				Nodes:   []string{"node1", "node2", "node3"},
+			},
+			availableNodes: map[string]bool{
+				"node1": true,
+				"node2": true,
+				"node3": false,
+			},
+			wantStatus:    StatusUnderReplicated,
+			wantAvailable: 2,
+			wantFailed:    1,
+		},
+		{
+			name: "unavailable - all replicas down",
+			pool: &v1alpha1.StoragePool{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-pool"},
+				Spec: v1alpha1.StoragePoolSpec{
+					DataProtection: v1alpha1.DataProtectionSpec{
+						Mode: "replication",
+						Replication: &v1alpha1.ReplicationSpec{
+							Factor: 3,
+						},
+					},
+				},
+			},
+			placement: &PlacementMap{
+				ChunkID: "chunk1",
+				Nodes:   []string{"node1", "node2", "node3"},
+			},
+			availableNodes: map[string]bool{
+				"node1": false,
+				"node2": false,
+				"node3": false,
+			},
+			wantStatus:    StatusUnavailable,
+			wantAvailable: 0,
+			wantFailed:    3,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			nodeChecker := &mockNodeChecker{availableNodes: tt.availableNodes}
+			metaClient := &mockMetadataClient{
+				placementMaps: map[string]*PlacementMap{
+					tt.placement.ChunkID: tt.placement,
+				},
+			}
+
+			checker := NewReplicationChecker(metaClient, nodeChecker)
+			volume := &VolumeMeta{
+				VolumeID: "vol1",
+				Pool:     tt.pool.Name,
+				ChunkIDs: []string{tt.placement.ChunkID},
+			}
+
+			result, err := checker.CheckChunk(ctx, tt.placement.ChunkID, volume, tt.pool)
+			if err != nil {
+				t.Fatalf("CheckChunk failed: %v", err)
+			}
+
+			if result.Status != tt.wantStatus {
+				t.Errorf("Status = %v, want %v", result.Status, tt.wantStatus)
+			}
+			if len(result.AvailableNodes) != tt.wantAvailable {
+				t.Errorf("AvailableNodes count = %d, want %d", len(result.AvailableNodes), tt.wantAvailable)
+			}
+			if len(result.FailedNodes) != tt.wantFailed {
+				t.Errorf("FailedNodes count = %d, want %d", len(result.FailedNodes), tt.wantFailed)
+			}
+		})
+	}
+}
+
+func TestErasureCodingChecker_CheckChunk(t *testing.T) {
+	tests := []struct {
+		name           string
+		pool           *v1alpha1.StoragePool
+		placement      *PlacementMap
+		availableNodes map[string]bool
+		wantStatus     ComplianceStatus
+		wantAvailable  int
+	}{
+		{
+			name: "fully compliant - all shards available",
+			pool: &v1alpha1.StoragePool{
+				ObjectMeta: metav1.ObjectMeta{Name: "ec-pool"},
+				Spec: v1alpha1.StoragePoolSpec{
+					DataProtection: v1alpha1.DataProtectionSpec{
+						Mode: "erasureCoding",
+						ErasureCoding: &v1alpha1.ErasureCodingSpec{
+							DataShards:   4,
+							ParityShards: 2,
+						},
+					},
+				},
+			},
+			placement: &PlacementMap{
+				ChunkID: "chunk1",
+				Nodes:   []string{"node1", "node2", "node3", "node4", "node5", "node6"},
+			},
+			availableNodes: map[string]bool{
+				"node1": true,
+				"node2": true,
+				"node3": true,
+				"node4": true,
+				"node5": true,
+				"node6": true,
+			},
+			wantStatus:    StatusCompliant,
+			wantAvailable: 6,
+		},
+		{
+			name: "under replicated - some shards lost but still recoverable",
+			pool: &v1alpha1.StoragePool{
+				ObjectMeta: metav1.ObjectMeta{Name: "ec-pool"},
+				Spec: v1alpha1.StoragePoolSpec{
+					DataProtection: v1alpha1.DataProtectionSpec{
+						Mode: "erasureCoding",
+						ErasureCoding: &v1alpha1.ErasureCodingSpec{
+							DataShards:   4,
+							ParityShards: 2,
+						},
+					},
+				},
+			},
+			placement: &PlacementMap{
+				ChunkID: "chunk1",
+				Nodes:   []string{"node1", "node2", "node3", "node4", "node5", "node6"},
+			},
+			availableNodes: map[string]bool{
+				"node1": true,
+				"node2": true,
+				"node3": true,
+				"node4": true,
+				"node5": false,
+				"node6": false,
+			},
+			wantStatus:    StatusUnderReplicated,
+			wantAvailable: 4,
+		},
+		{
+			name: "unavailable - insufficient shards for recovery",
+			pool: &v1alpha1.StoragePool{
+				ObjectMeta: metav1.ObjectMeta{Name: "ec-pool"},
+				Spec: v1alpha1.StoragePoolSpec{
+					DataProtection: v1alpha1.DataProtectionSpec{
+						Mode: "erasureCoding",
+						ErasureCoding: &v1alpha1.ErasureCodingSpec{
+							DataShards:   4,
+							ParityShards: 2,
+						},
+					},
+				},
+			},
+			placement: &PlacementMap{
+				ChunkID: "chunk1",
+				Nodes:   []string{"node1", "node2", "node3", "node4", "node5", "node6"},
+			},
+			availableNodes: map[string]bool{
+				"node1": true,
+				"node2": true,
+				"node3": false,
+				"node4": false,
+				"node5": false,
+				"node6": false,
+			},
+			wantStatus:    StatusUnavailable,
+			wantAvailable: 2,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			nodeChecker := &mockNodeChecker{availableNodes: tt.availableNodes}
+			metaClient := &mockMetadataClient{
+				placementMaps: map[string]*PlacementMap{
+					tt.placement.ChunkID: tt.placement,
+				},
+			}
+
+			checker := NewErasureCodingChecker(metaClient, nodeChecker)
+			volume := &VolumeMeta{
+				VolumeID: "vol1",
+				Pool:     tt.pool.Name,
+				ChunkIDs: []string{tt.placement.ChunkID},
+			}
+
+			result, err := checker.CheckChunk(ctx, tt.placement.ChunkID, volume, tt.pool)
+			if err != nil {
+				t.Fatalf("CheckChunk failed: %v", err)
+			}
+
+			if result.Status != tt.wantStatus {
+				t.Errorf("Status = %v, want %v", result.Status, tt.wantStatus)
+			}
+			if len(result.AvailableNodes) != tt.wantAvailable {
+				t.Errorf("AvailableNodes count = %d, want %d", len(result.AvailableNodes), tt.wantAvailable)
+			}
+		})
+	}
+}
+
+func TestPolicyEngine_CheckVolumeCompliance(t *testing.T) {
+	ctx := context.Background()
+
+	pool := &v1alpha1.StoragePool{
+		ObjectMeta: metav1.ObjectMeta{Name: "replica-pool"},
+		Spec: v1alpha1.StoragePoolSpec{
+			DataProtection: v1alpha1.DataProtectionSpec{
+				Mode: "replication",
+				Replication: &v1alpha1.ReplicationSpec{
+					Factor: 3,
+				},
+			},
+		},
+	}
+
+	volume := &VolumeMeta{
+		VolumeID: "vol1",
+		Pool:     "replica-pool",
+		ChunkIDs: []string{"chunk1", "chunk2", "chunk3"},
+	}
+
+	nodeChecker := &mockNodeChecker{
+		availableNodes: map[string]bool{
+			"node1": true,
+			"node2": true,
+			"node3": false, // chunk1 has a failed replica
+		},
+	}
+
+	metaClient := &mockMetadataClient{
+		volumes: map[string]*VolumeMeta{
+			volume.VolumeID: volume,
+		},
+		placementMaps: map[string]*PlacementMap{
+			"chunk1": {ChunkID: "chunk1", Nodes: []string{"node1", "node2", "node3"}},
+			"chunk2": {ChunkID: "chunk2", Nodes: []string{"node1", "node2", "node3"}},
+			"chunk3": {ChunkID: "chunk3", Nodes: []string{"node1", "node2", "node3"}},
+		},
+	}
+
+	engine := NewPolicyEngine(metaClient, nodeChecker)
+
+	report, err := engine.CheckVolumeCompliance(ctx, volume, pool)
+	if err != nil {
+		t.Fatalf("CheckVolumeCompliance failed: %v", err)
+	}
+
+	if report.VolumeID != volume.VolumeID {
+		t.Errorf("VolumeID = %s, want %s", report.VolumeID, volume.VolumeID)
+	}
+	if report.Pool != volume.Pool {
+		t.Errorf("Pool = %s, want %s", report.Pool, volume.Pool)
+	}
+	if report.TotalChunks != 3 {
+		t.Errorf("TotalChunks = %d, want 3", report.TotalChunks)
+	}
+	// All 3 chunks have node3 unavailable, so all are under-replicated
+	if report.CompliantChunks != 0 {
+		t.Errorf("CompliantChunks = %d, want 0", report.CompliantChunks)
+	}
+	if report.UnderReplicatedChunks != 3 {
+		t.Errorf("UnderReplicatedChunks = %d, want 3", report.UnderReplicatedChunks)
+	}
+}
+
+func TestPolicyEngine_CheckPoolCompliance(t *testing.T) {
+	ctx := context.Background()
+
+	pool := &v1alpha1.StoragePool{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-pool"},
+		Spec: v1alpha1.StoragePoolSpec{
+			DataProtection: v1alpha1.DataProtectionSpec{
+				Mode: "replication",
+				Replication: &v1alpha1.ReplicationSpec{
+					Factor: 3,
+				},
+			},
+		},
+	}
+
+	volumes := map[string]*VolumeMeta{
+		"vol1": {
+			VolumeID: "vol1",
+			Pool:     "test-pool",
+			ChunkIDs: []string{"chunk1", "chunk2"},
+		},
+		"vol2": {
+			VolumeID: "vol2",
+			Pool:     "test-pool",
+			ChunkIDs: []string{"chunk3"},
+		},
+	}
+
+	nodeChecker := &mockNodeChecker{
+		availableNodes: map[string]bool{
+			"node1": true,
+			"node2": true,
+			"node3": true,
+		},
+	}
+
+	metaClient := &mockMetadataClient{
+		volumes: volumes,
+		placementMaps: map[string]*PlacementMap{
+			"chunk1": {ChunkID: "chunk1", Nodes: []string{"node1", "node2", "node3"}},
+			"chunk2": {ChunkID: "chunk2", Nodes: []string{"node1", "node2", "node3"}},
+			"chunk3": {ChunkID: "chunk3", Nodes: []string{"node1", "node2", "node3"}},
+		},
+	}
+
+	engine := NewPolicyEngine(metaClient, nodeChecker)
+
+	report, err := engine.CheckPoolCompliance(ctx, pool)
+	if err != nil {
+		t.Fatalf("CheckPoolCompliance failed: %v", err)
+	}
+
+	if report.PoolName != pool.Name {
+		t.Errorf("PoolName = %s, want %s", report.PoolName, pool.Name)
+	}
+	if report.ProtectionMode != "replication" {
+		t.Errorf("ProtectionMode = %s, want replication", report.ProtectionMode)
+	}
+	if report.TotalVolumes != 2 {
+		t.Errorf("TotalVolumes = %d, want 2", report.TotalVolumes)
+	}
+	if report.TotalChunks != 3 {
+		t.Errorf("TotalChunks = %d, want 3", report.TotalChunks)
+	}
+	if !report.IsCompliant {
+		t.Errorf("IsCompliant = false, want true (all chunks should be compliant)")
+	}
+}
+
+func TestReconciler_ScanAndEnqueue(t *testing.T) {
+	ctx := context.Background()
+
+	pool := &v1alpha1.StoragePool{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-pool"},
+		Spec: v1alpha1.StoragePoolSpec{
+			DataProtection: v1alpha1.DataProtectionSpec{
+				Mode: "replication",
+				Replication: &v1alpha1.ReplicationSpec{
+					Factor: 3,
+				},
+			},
+		},
+	}
+
+	volume := &VolumeMeta{
+		VolumeID: "vol1",
+		Pool:     "test-pool",
+		ChunkIDs: []string{"chunk1", "chunk2"},
+	}
+
+	nodeChecker := &mockNodeChecker{
+		availableNodes: map[string]bool{
+			"node1": true,
+			"node2": true,
+			"node3": false, // One replica is down
+		},
+	}
+
+	poolLookup := &mockPoolLookup{
+		pools: map[string]*v1alpha1.StoragePool{
+			"test-pool": pool,
+		},
+	}
+
+	metaClient := &mockMetadataClient{
+		volumes: map[string]*VolumeMeta{
+			"vol1": volume,
+		},
+		placementMaps: map[string]*PlacementMap{
+			"chunk1": {ChunkID: "chunk1", Nodes: []string{"node1", "node2", "node3"}},
+			"chunk2": {ChunkID: "chunk2", Nodes: []string{"node1", "node2", "node3"}},
+		},
+	}
+
+	reconciler := NewReconciler(metaClient, nodeChecker, poolLookup)
+
+	summary, err := reconciler.ScanAndEnqueue(ctx)
+	if err != nil {
+		t.Fatalf("ScanAndEnqueue failed: %v", err)
+	}
+
+	if summary.TasksQueued != 2 {
+		t.Errorf("TasksQueued = %d, want 2 (both chunks need repair)", summary.TasksQueued)
+	}
+
+	if reconciler.QueueSize() != 2 {
+		t.Errorf("QueueSize = %d, want 2", reconciler.QueueSize())
+	}
+}
+
+func TestComplianceStatus_String(t *testing.T) {
+	tests := []struct {
+		status ComplianceStatus
+		want   string
+	}{
+		{StatusCompliant, "compliant"},
+		{StatusUnderReplicated, "under_replicated"},
+		{StatusUnavailable, "unavailable"},
+		{StatusCorrupted, "corrupted"},
+		{ComplianceStatus(99), "unknown"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.want, func(t *testing.T) {
+			if got := tt.status.String(); got != tt.want {
+				t.Errorf("String() = %s, want %s", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/policy/controller_integration.go
+++ b/internal/policy/controller_integration.go
@@ -1,0 +1,72 @@
+package policy
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/piwi3910/novastor/api/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// K8sPoolLookup implements PoolLookup using the Kubernetes API.
+type K8sPoolLookup struct {
+	client client.Client
+}
+
+// NewK8sPoolLookup creates a new K8sPoolLookup.
+func NewK8sPoolLookup(client client.Client) *K8sPoolLookup {
+	return &K8sPoolLookup{client: client}
+}
+
+// ListPools retrieves all StoragePool resources from Kubernetes.
+func (l *K8sPoolLookup) ListPools(ctx context.Context) ([]*v1alpha1.StoragePool, error) {
+	var poolList v1alpha1.StoragePoolList
+	if err := l.client.List(ctx, &poolList); err != nil {
+		return nil, fmt.Errorf("listing storage pools: %w", err)
+	}
+
+	pools := make([]*v1alpha1.StoragePool, len(poolList.Items))
+	for i := range poolList.Items {
+		pools[i] = &poolList.Items[i]
+	}
+	return pools, nil
+}
+
+// GetPool retrieves a single StoragePool by name from Kubernetes.
+func (l *K8sPoolLookup) GetPool(ctx context.Context, name string) (*v1alpha1.StoragePool, error) {
+	var pool v1alpha1.StoragePool
+	if err := l.client.Get(ctx, client.ObjectKey{Name: name}, &pool); err != nil {
+		return nil, fmt.Errorf("getting storage pool %s: %w", name, err)
+	}
+	return &pool, nil
+}
+
+// K8sNodeAvailabilityChecker implements NodeAvailabilityChecker using the Kubernetes API.
+// It checks if a node is Ready according to Kubernetes.
+type K8sNodeAvailabilityChecker struct {
+	client client.Client
+}
+
+// NewK8sNodeAvailabilityChecker creates a new K8sNodeAvailabilityChecker.
+func NewK8sNodeAvailabilityChecker(client client.Client) *K8sNodeAvailabilityChecker {
+	return &K8sNodeAvailabilityChecker{client: client}
+}
+
+// IsNodeAvailable checks if a Kubernetes node is Ready.
+func (c *K8sNodeAvailabilityChecker) IsNodeAvailable(ctx context.Context, nodeID string) bool {
+	// Check if there's a Node resource matching the nodeID
+	var node corev1.Node
+	if err := c.client.Get(ctx, client.ObjectKey{Name: nodeID}, &node); err != nil {
+		return false
+	}
+
+	// Check the Ready condition
+	for _, condition := range node.Status.Conditions {
+		if condition.Type == corev1.NodeReady {
+			return condition.Status == corev1.ConditionTrue
+		}
+	}
+
+	return false
+}

--- a/internal/policy/erasure_checker.go
+++ b/internal/policy/erasure_checker.go
@@ -1,0 +1,175 @@
+package policy
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/piwi3910/novastor/api/v1alpha1"
+)
+
+// ErasureCodingChecker verifies compliance for erasure-coded chunks.
+type ErasureCodingChecker struct {
+	metaClient  MetadataClient
+	nodeChecker NodeAvailabilityChecker
+}
+
+// NewErasureCodingChecker creates a new ErasureCodingChecker.
+func NewErasureCodingChecker(metaClient MetadataClient, nodeChecker NodeAvailabilityChecker) *ErasureCodingChecker {
+	return &ErasureCodingChecker{
+		metaClient:  metaClient,
+		nodeChecker: nodeChecker,
+	}
+}
+
+// RequiredReplicas returns the total number of shards (data + parity).
+func (c *ErasureCodingChecker) RequiredReplicas() int {
+	// This is a placeholder; the actual shard counts come from the pool spec.
+	return 6 // 4 data + 2 parity default
+}
+
+// CheckChunk verifies that an erasure-coded chunk has sufficient available shards for recovery.
+func (c *ErasureCodingChecker) CheckChunk(ctx context.Context, chunkID string, volume *VolumeMeta, pool *v1alpha1.StoragePool) (*ChunkComplianceResult, error) {
+	if pool.Spec.DataProtection.Mode != "erasureCoding" {
+		return nil, fmt.Errorf("pool %s is not in erasure coding mode", pool.Name)
+	}
+
+	ecSpec := pool.Spec.DataProtection.ErasureCoding
+	if ecSpec == nil {
+		return nil, fmt.Errorf("pool %s has nil erasure coding spec", pool.Name)
+	}
+
+	dataShards := ecSpec.DataShards
+	if dataShards == 0 {
+		dataShards = 4 // Default
+	}
+	parityShards := ecSpec.ParityShards
+	if parityShards == 0 {
+		parityShards = 2 // Default
+	}
+
+	totalShards := dataShards + parityShards
+	minShardsForRecovery := dataShards
+
+	// Get the placement map for this chunk.
+	placement, err := c.metaClient.GetPlacementMap(ctx, chunkID)
+	if err != nil {
+		return nil, fmt.Errorf("getting placement map for chunk %s: %w", chunkID, err)
+	}
+
+	result := &ChunkComplianceResult{
+		ChunkID:        chunkID,
+		VolumeID:       volume.VolumeID,
+		Pool:           pool.Name,
+		ProtectionMode: "erasure_coding",
+		ExpectedCount:  totalShards,
+	}
+
+	// Check availability of each node in the placement map.
+	for _, nodeID := range placement.Nodes {
+		if c.nodeChecker.IsNodeAvailable(ctx, nodeID) {
+			result.AvailableNodes = append(result.AvailableNodes, nodeID)
+		} else {
+			result.FailedNodes = append(result.FailedNodes, nodeID)
+		}
+	}
+
+	result.ActualCount = len(result.AvailableNodes)
+
+	// Determine compliance status.
+	// For erasure coding:
+	// - Compliant: all shards available
+	// - UnderReplicated: some shards lost but still recoverable (>= dataShards available)
+	// - Unavailable: insufficient shards for recovery (< dataShards available)
+	if result.ActualCount == 0 {
+		result.Status = StatusUnavailable
+	} else if result.ActualCount < minShardsForRecovery {
+		result.Status = StatusUnavailable
+	} else if result.ActualCount < totalShards {
+		result.Status = StatusUnderReplicated
+	} else {
+		result.Status = StatusCompliant
+	}
+
+	return result, nil
+}
+
+// CheckChunkWithIntegrity verifies chunk compliance including data integrity checks.
+// It attempts to decode the erasure-coded data to verify it can be reconstructed.
+func (c *ErasureCodingChecker) CheckChunkWithIntegrity(ctx context.Context, chunkID string, volume *VolumeMeta, pool *v1alpha1.StoragePool, shardReader ShardReader) (*ChunkComplianceResult, error) {
+	result, err := c.CheckChunk(ctx, chunkID, volume, pool)
+	if err != nil {
+		return nil, err
+	}
+
+	// If we don't have enough shards to potentially reconstruct, skip integrity check.
+	ecSpec := pool.Spec.DataProtection.ErasureCoding
+	if ecSpec == nil {
+		return result, nil
+	}
+
+	dataShards := ecSpec.DataShards
+	if dataShards == 0 {
+		dataShards = 4
+	}
+
+	if len(result.AvailableNodes) < dataShards {
+		return result, nil
+	}
+
+	// Try to read and verify the chunk can be reconstructed.
+	if shardReader != nil {
+		corrupted, verifyErr := shardReader.VerifyErasureChunk(ctx, chunkID, result.AvailableNodes, dataShards)
+		if verifyErr != nil {
+			// Log the error but don't fail the compliance check entirely
+			return result, nil
+		}
+		if corrupted {
+			result.Status = StatusCorrupted
+		}
+	}
+
+	return result, nil
+}
+
+// ShardReader can read erasure-coded shards and verify data integrity.
+type ShardReader interface {
+	// VerifyErasureChunk reads shards from the given nodes and attempts reconstruction.
+	// Returns true if the data is corrupted (cannot be reconstructed or checksum fails).
+	VerifyErasureChunk(ctx context.Context, chunkID string, nodes []string, minShards int) (corrupted bool, err error)
+}
+
+// ShardReplicator can regenerate and replicate a lost shard.
+type ShardReplicator interface {
+	// RegenerateShard recreates a lost shard from available shards and stores it on the destination node.
+	RegenerateShard(ctx context.Context, chunkID string, sourceNodes []string, destNode string, dataShards, parityShards int) error
+}
+
+// RepairChunk regenerates a lost shard from available shards.
+func (c *ErasureCodingChecker) RepairChunk(ctx context.Context, chunkID string, sourceNodes []string, destNode string, dataShards, parityShards int, replicator ShardReplicator) error {
+	if replicator == nil {
+		return fmt.Errorf("shard replicator is nil")
+	}
+	return replicator.RegenerateShard(ctx, chunkID, sourceNodes, destNode, dataShards, parityShards)
+}
+
+// GetMinShardsForRecovery returns the minimum number of shards needed to recover data.
+func GetMinShardsForRecovery(ecSpec *v1alpha1.ErasureCodingSpec) int {
+	if ecSpec == nil {
+		return 4 // Default
+	}
+	if ecSpec.DataShards > 0 {
+		return ecSpec.DataShards
+	}
+	return 4 // Default
+}
+
+// ValidateErasureCodingConfig checks if the erasure coding configuration is valid.
+func ValidateErasureCodingConfig(dataShards, parityShards int) error {
+	if dataShards <= 0 {
+		return fmt.Errorf("data shards must be positive, got %d", dataShards)
+	}
+	if parityShards <= 0 {
+		return fmt.Errorf("parity shards must be positive, got %d", parityShards)
+	}
+	return nil
+}

--- a/internal/policy/metrics.go
+++ b/internal/policy/metrics.go
@@ -1,0 +1,63 @@
+package policy
+
+import (
+	"time"
+
+	"github.com/piwi3910/novastor/internal/metrics"
+)
+
+// MetricsReporter records compliance and repair metrics.
+type MetricsReporter struct{}
+
+// NewMetricsReporter creates a new MetricsReporter.
+func NewMetricsReporter() *MetricsReporter {
+	return &MetricsReporter{}
+}
+
+// ReportPoolCompliance records the compliance status for a pool.
+func (m *MetricsReporter) ReportPoolCompliance(poolName, mode string, isCompliant bool) {
+	status := 0.0
+	if isCompliant {
+		status = 1.0
+	}
+	metrics.PoolComplianceStatus.WithLabelValues(poolName, mode).Set(status)
+}
+
+// ReportChunkViolations records the number of chunks with each compliance status.
+func (m *MetricsReporter) ReportChunkViolations(poolName string, compliant, underReplicated, unavailable, corrupted int) {
+	metrics.ChunkComplianceViolations.WithLabelValues(poolName, "compliant").Set(float64(compliant))
+	metrics.ChunkComplianceViolations.WithLabelValues(poolName, "under_replicated").Set(float64(underReplicated))
+	metrics.ChunkComplianceViolations.WithLabelValues(poolName, "unavailable").Set(float64(unavailable))
+	metrics.ChunkComplianceViolations.WithLabelValues(poolName, "corrupted").Set(float64(corrupted))
+}
+
+// ReportScanStart records the start of a compliance scan.
+func (m *MetricsReporter) ReportScanStart(scope string) time.Time {
+	return time.Now()
+}
+
+// ReportScanComplete records the completion of a compliance scan.
+func (m *MetricsReporter) ReportScanComplete(scope string, start time.Time) {
+	duration := time.Since(start).Seconds()
+	metrics.PolicyScanDuration.WithLabelValues(scope).Observe(duration)
+}
+
+// ReportRepairQueued records the number of chunks queued for repair.
+func (m *MetricsReporter) ReportRepairQueued(count int) {
+	metrics.PolicyRepairQueued.Set(float64(count))
+}
+
+// ReportRepairCompleted records a completed repair operation.
+func (m *MetricsReporter) ReportRepairCompleted() {
+	metrics.PolicyRepairCompleted.Inc()
+}
+
+// ReportRepairFailed records a failed repair operation.
+func (m *MetricsReporter) ReportRepairFailed() {
+	metrics.PolicyRepairFailed.Inc()
+}
+
+// ReportRepairDuration records the time taken for a repair operation.
+func (m *MetricsReporter) ReportRepairDuration(duration time.Duration) {
+	metrics.PolicyRepairDuration.Observe(duration.Seconds())
+}

--- a/internal/policy/reconciler.go
+++ b/internal/policy/reconciler.go
@@ -1,0 +1,436 @@
+package policy
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	"go.uber.org/zap"
+
+	"github.com/piwi3910/novastor/api/v1alpha1"
+	"github.com/piwi3910/novastor/internal/logging"
+)
+
+// Reconciler repairs non-compliant chunks to restore data protection.
+type Reconciler struct {
+	metaClient      MetadataClient
+	nodeChecker     NodeAvailabilityChecker
+	poolLookup      PoolLookup
+	chunkReplicator ChunkReplicator
+	shardReplicator ShardReplicator
+
+	mu               sync.Mutex
+	maxConcurrent    int
+	repairQueue      []RepairTask
+	completedRepairs int64
+	failedRepairs    int64
+	lastScanTime     time.Time
+	lastScanDuration time.Duration
+}
+
+// RepairTask represents a chunk that needs repair.
+type RepairTask struct {
+	ChunkID        string           `json:"chunkID"`
+	VolumeID       string           `json:"volumeID"`
+	Pool           string           `json:"pool"`
+	ProtectionMode string           `json:"protectionMode"`
+	Status         ComplianceStatus `json:"status"`
+	AvailableNodes []string         `json:"availableNodes"`
+	FailedNodes    []string         `json:"failedNodes"`
+	Priority       int              `json:"priority"` // Lower is more urgent
+	CreatedAt      time.Time        `json:"createdAt"`
+}
+
+// RepairSummary contains statistics about a repair operation.
+type RepairSummary struct {
+	TasksQueued    int           `json:"tasksQueued"`
+	TasksCompleted int           `json:"tasksCompleted"`
+	TasksFailed    int           `json:"tasksFailed"`
+	Duration       time.Duration `json:"duration"`
+}
+
+// NewReconciler creates a new Reconciler.
+func NewReconciler(metaClient MetadataClient, nodeChecker NodeAvailabilityChecker, poolLookup PoolLookup) *Reconciler {
+	return &Reconciler{
+		metaClient:    metaClient,
+		nodeChecker:   nodeChecker,
+		poolLookup:    poolLookup,
+		maxConcurrent: 4,
+		repairQueue:   make([]RepairTask, 0),
+	}
+}
+
+// SetChunkReplicator sets the chunk replicator for repairing replicated chunks.
+func (r *Reconciler) SetChunkReplicator(replicator ChunkReplicator) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.chunkReplicator = replicator
+}
+
+// SetShardReplicator sets the shard replicator for repairing erasure-coded chunks.
+func (r *Reconciler) SetShardReplicator(replicator ShardReplicator) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.shardReplicator = replicator
+}
+
+// SetMaxConcurrent sets the maximum number of concurrent repair operations.
+func (r *Reconciler) SetMaxConcurrent(n int) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if n > 0 {
+		r.maxConcurrent = n
+	}
+}
+
+// ScanAndEnqueue scans all pools for non-compliant chunks and enqueues repair tasks.
+func (r *Reconciler) ScanAndEnqueue(ctx context.Context) (*RepairSummary, error) {
+	startTime := time.Now()
+
+	engine := NewPolicyEngine(r.metaClient, r.nodeChecker)
+	reports, err := engine.CheckAllPoolsCompliance(ctx, r.poolLookup)
+	if err != nil {
+		return nil, fmt.Errorf("checking compliance: %w", err)
+	}
+
+	queuedCount := 0
+	for poolName, report := range reports {
+		if report.IsCompliant {
+			continue
+		}
+
+		for _, volumeReport := range report.VolumeReports {
+			for _, chunkResult := range volumeReport.ChunkResults {
+				if chunkResult.Status == StatusCompliant {
+					continue
+				}
+
+				// Calculate priority: fewer available replicas = higher priority
+				priority := len(chunkResult.AvailableNodes)
+				if chunkResult.Status == StatusCorrupted {
+					priority = -1 // Highest priority for corrupted chunks
+				}
+
+				task := RepairTask{
+					ChunkID:        chunkResult.ChunkID,
+					VolumeID:       chunkResult.VolumeID,
+					Pool:           poolName,
+					ProtectionMode: chunkResult.ProtectionMode,
+					Status:         chunkResult.Status,
+					AvailableNodes: chunkResult.AvailableNodes,
+					FailedNodes:    chunkResult.FailedNodes,
+					Priority:       priority,
+					CreatedAt:      time.Now(),
+				}
+
+				r.mu.Lock()
+				r.repairQueue = append(r.repairQueue, task)
+				r.mu.Unlock()
+
+				queuedCount++
+			}
+		}
+	}
+
+	// Sort queue by priority (lower first)
+	r.sortQueue()
+
+	scanDuration := time.Since(startTime)
+	r.mu.Lock()
+	r.lastScanTime = startTime
+	r.lastScanDuration = scanDuration
+	r.mu.Unlock()
+
+	logging.L.Info("compliance scan completed",
+		zap.Int("tasksQueued", queuedCount),
+		zap.Duration("scanDuration", scanDuration),
+	)
+
+	return &RepairSummary{
+		TasksQueued: queuedCount,
+		Duration:    scanDuration,
+	}, nil
+}
+
+// ProcessQueue processes pending repair tasks with a concurrency limit.
+func (r *Reconciler) ProcessQueue(ctx context.Context) error {
+	r.mu.Lock()
+	tasks := make([]RepairTask, len(r.repairQueue))
+	copy(tasks, r.repairQueue)
+	r.repairQueue = make([]RepairTask, 0)
+	r.mu.Unlock()
+
+	if len(tasks) == 0 {
+		return nil
+	}
+
+	logging.L.Info("processing repair queue",
+		zap.Int("tasks", len(tasks)),
+		zap.Int("concurrency", r.maxConcurrent),
+	)
+
+	sem := make(chan struct{}, r.maxConcurrent)
+	var wg sync.WaitGroup
+	var mu sync.Mutex
+	var completed, failed int
+
+	for _, task := range tasks {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case sem <- struct{}{}:
+		}
+
+		wg.Add(1)
+		go func(t RepairTask) {
+			defer wg.Done()
+			defer func() { <-sem }()
+
+			if err := r.repairTask(ctx, t); err != nil {
+				logging.L.Error("failed to repair chunk",
+					zap.String("chunkID", t.ChunkID),
+					zap.String("pool", t.Pool),
+					zap.Error(err),
+				)
+				mu.Lock()
+				failed++
+				r.failedRepairs++
+				mu.Unlock()
+				return
+			}
+
+			mu.Lock()
+			completed++
+			r.completedRepairs++
+			mu.Unlock()
+
+			logging.L.Debug("repaired chunk",
+				zap.String("chunkID", t.ChunkID),
+				zap.String("pool", t.Pool),
+				zap.String("mode", t.ProtectionMode),
+			)
+		}(task)
+	}
+
+	wg.Wait()
+
+	logging.L.Info("repair queue processing completed",
+		zap.Int("completed", completed),
+		zap.Int("failed", failed),
+	)
+
+	return nil
+}
+
+// repairTask performs a single repair operation.
+func (r *Reconciler) repairTask(ctx context.Context, task RepairTask) error {
+	pool, err := r.poolLookup.GetPool(ctx, task.Pool)
+	if err != nil {
+		return fmt.Errorf("getting pool %s: %w", task.Pool, err)
+	}
+
+	// Get healthy nodes for potential repair targets
+	nodes, err := r.metaClient.ListNodeMetas(ctx)
+	if err != nil {
+		return fmt.Errorf("listing nodes: %w", err)
+	}
+
+	var healthyNodes []string
+	for _, node := range nodes {
+		if r.nodeChecker.IsNodeAvailable(ctx, node.NodeID) {
+			// Skip nodes that already have this chunk
+			alreadyHas := false
+			for _, n := range task.AvailableNodes {
+				if n == node.NodeID {
+					alreadyHas = true
+					break
+				}
+			}
+			if !alreadyHas {
+				healthyNodes = append(healthyNodes, node.NodeID)
+			}
+		}
+	}
+
+	if len(healthyNodes) == 0 {
+		return fmt.Errorf("no healthy nodes available for repair")
+	}
+
+	switch task.ProtectionMode {
+	case "replication":
+		return r.repairReplicatedChunk(ctx, task, pool, healthyNodes)
+	case "erasureCoding":
+		return r.repairErasureChunk(ctx, task, pool, healthyNodes)
+	default:
+		return fmt.Errorf("unknown protection mode: %s", task.ProtectionMode)
+	}
+}
+
+// repairReplicatedChunk replicates a chunk to a new node.
+func (r *Reconciler) repairReplicatedChunk(ctx context.Context, task RepairTask, pool *v1alpha1.StoragePool, healthyNodes []string) error {
+	if len(task.AvailableNodes) == 0 {
+		return fmt.Errorf("no available replicas for chunk %s", task.ChunkID)
+	}
+
+	if r.chunkReplicator == nil {
+		return fmt.Errorf("chunk replicator not configured")
+	}
+
+	// Pick first available node as source
+	sourceNode := task.AvailableNodes[0]
+	destNode := healthyNodes[0]
+
+	if err := r.chunkReplicator.ReplicateChunk(ctx, task.ChunkID, sourceNode, destNode); err != nil {
+		return fmt.Errorf("replicating chunk: %w", err)
+	}
+
+	// Update placement map
+	placement, err := r.metaClient.GetPlacementMap(ctx, task.ChunkID)
+	if err != nil {
+		return fmt.Errorf("getting placement map: %w", err)
+	}
+
+	// Replace a failed node with the new node
+	updated := false
+	for i, node := range placement.Nodes {
+		isFailed := false
+		for _, failed := range task.FailedNodes {
+			if node == failed {
+				isFailed = true
+				break
+			}
+		}
+		if isFailed && !updated {
+			placement.Nodes[i] = destNode
+			updated = true
+			break
+		}
+	}
+
+	if !updated {
+		// Add the new node if we didn't replace a failed one
+		placement.Nodes = append(placement.Nodes, destNode)
+	}
+
+	if err := r.metaClient.PutPlacementMap(ctx, placement); err != nil {
+		return fmt.Errorf("updating placement map: %w", err)
+	}
+
+	return nil
+}
+
+// repairErasureChunk regenerates a lost shard.
+func (r *Reconciler) repairErasureChunk(ctx context.Context, task RepairTask, pool *v1alpha1.StoragePool, healthyNodes []string) error {
+	if len(task.AvailableNodes) == 0 {
+		return fmt.Errorf("no available shards for chunk %s", task.ChunkID)
+	}
+
+	if r.shardReplicator == nil {
+		return fmt.Errorf("shard replicator not configured")
+	}
+
+	ecSpec := pool.Spec.DataProtection.ErasureCoding
+	if ecSpec == nil {
+		return fmt.Errorf("pool has nil erasure coding spec")
+	}
+
+	dataShards := ecSpec.DataShards
+	if dataShards == 0 {
+		dataShards = 4
+	}
+	parityShards := ecSpec.ParityShards
+	if parityShards == 0 {
+		parityShards = 2
+	}
+
+	destNode := healthyNodes[0]
+
+	if err := r.shardReplicator.RegenerateShard(ctx, task.ChunkID, task.AvailableNodes, destNode, dataShards, parityShards); err != nil {
+		return fmt.Errorf("regenerating shard: %w", err)
+	}
+
+	// Update placement map
+	placement, err := r.metaClient.GetPlacementMap(ctx, task.ChunkID)
+	if err != nil {
+		return fmt.Errorf("getting placement map: %w", err)
+	}
+
+	// Replace a failed node with the new node
+	updated := false
+	for i, node := range placement.Nodes {
+		isFailed := false
+		for _, failed := range task.FailedNodes {
+			if node == failed {
+				isFailed = true
+				break
+			}
+		}
+		if isFailed && !updated {
+			placement.Nodes[i] = destNode
+			updated = true
+			break
+		}
+	}
+
+	if !updated {
+		// Add the new node if we didn't replace a failed one
+		placement.Nodes = append(placement.Nodes, destNode)
+	}
+
+	if err := r.metaClient.PutPlacementMap(ctx, placement); err != nil {
+		return fmt.Errorf("updating placement map: %w", err)
+	}
+
+	return nil
+}
+
+// sortQueue sorts the repair queue by priority (lower first).
+func (r *Reconciler) sortQueue() {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	// Sort by priority (lower = more urgent), then by creation time (older first)
+	for i := 0; i < len(r.repairQueue); i++ {
+		for j := i + 1; j < len(r.repairQueue); j++ {
+			if r.repairQueue[i].Priority > r.repairQueue[j].Priority ||
+				(r.repairQueue[i].Priority == r.repairQueue[j].Priority &&
+					r.repairQueue[i].CreatedAt.After(r.repairQueue[j].CreatedAt)) {
+				r.repairQueue[i], r.repairQueue[j] = r.repairQueue[j], r.repairQueue[i]
+			}
+		}
+	}
+}
+
+// QueueSize returns the number of pending repair tasks.
+func (r *Reconciler) QueueSize() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return len(r.repairQueue)
+}
+
+// CompletedRepairs returns the total number of completed repairs.
+func (r *Reconciler) CompletedRepairs() int64 {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.completedRepairs
+}
+
+// FailedRepairs returns the total number of failed repairs.
+func (r *Reconciler) FailedRepairs() int64 {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.failedRepairs
+}
+
+// LastScanInfo returns information about the last compliance scan.
+func (r *Reconciler) LastScanInfo() (lastScan time.Time, duration time.Duration) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.lastScanTime, r.lastScanDuration
+}
+
+// getPoolLookup returns the pool lookup for use by the policy engine runnable.
+func (r *Reconciler) getPoolLookup() PoolLookup {
+	return r.poolLookup
+}

--- a/internal/policy/replication_checker.go
+++ b/internal/policy/replication_checker.go
@@ -1,0 +1,164 @@
+package policy
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/piwi3910/novastor/api/v1alpha1"
+)
+
+// MetadataClient is the interface for accessing metadata.
+// This allows the policy engine to work with different implementations.
+type MetadataClient interface {
+	GetPlacementMap(ctx context.Context, chunkID string) (*PlacementMap, error)
+	PutPlacementMap(ctx context.Context, pm *PlacementMap) error
+	ListPlacementMaps(ctx context.Context) ([]*PlacementMap, error)
+	ListNodeMetas(ctx context.Context) ([]*NodeMeta, error)
+	GetVolumeMeta(ctx context.Context, volumeID string) (*VolumeMeta, error)
+	ListVolumesMeta(ctx context.Context) ([]*VolumeMeta, error)
+}
+
+// PlacementMap represents where chunks are stored.
+type PlacementMap struct {
+	ChunkID string   `json:"chunkID"`
+	Nodes   []string `json:"nodes"`
+}
+
+// NodeMeta represents metadata about a storage node.
+type NodeMeta struct {
+	NodeID        string `json:"nodeID"`
+	Address       string `json:"address"`
+	LastHeartbeat int64  `json:"lastHeartbeat"`
+}
+
+// VolumeMeta represents metadata about a volume.
+type VolumeMeta struct {
+	VolumeID  string   `json:"volumeID"`
+	Pool      string   `json:"pool"`
+	SizeBytes uint64   `json:"sizeBytes"`
+	ChunkIDs  []string `json:"chunkIDs"`
+}
+
+// ReplicationChecker verifies compliance for replication-mode chunks.
+type ReplicationChecker struct {
+	metaClient  MetadataClient
+	nodeChecker NodeAvailabilityChecker
+}
+
+// NewReplicationChecker creates a new ReplicationChecker.
+func NewReplicationChecker(metaClient MetadataClient, nodeChecker NodeAvailabilityChecker) *ReplicationChecker {
+	return &ReplicationChecker{
+		metaClient:  metaClient,
+		nodeChecker: nodeChecker,
+	}
+}
+
+// RequiredReplicas returns the replication factor from the pool spec.
+func (c *ReplicationChecker) RequiredReplicas() int {
+	// This is a placeholder; the actual factor comes from the pool spec passed to CheckChunk.
+	return 3
+}
+
+// CheckChunk verifies that a replicated chunk has the required number of healthy replicas.
+func (c *ReplicationChecker) CheckChunk(ctx context.Context, chunkID string, volume *VolumeMeta, pool *v1alpha1.StoragePool) (*ChunkComplianceResult, error) {
+	if pool.Spec.DataProtection.Mode != "replication" {
+		return nil, fmt.Errorf("pool %s is not in replication mode", pool.Name)
+	}
+
+	replicationSpec := pool.Spec.DataProtection.Replication
+	if replicationSpec == nil {
+		return nil, fmt.Errorf("pool %s has nil replication spec", pool.Name)
+	}
+
+	expectedCount := replicationSpec.Factor
+	if expectedCount == 0 {
+		expectedCount = 3 // Default
+	}
+
+	// Get the placement map for this chunk.
+	placement, err := c.metaClient.GetPlacementMap(ctx, chunkID)
+	if err != nil {
+		return nil, fmt.Errorf("getting placement map for chunk %s: %w", chunkID, err)
+	}
+
+	result := &ChunkComplianceResult{
+		ChunkID:        chunkID,
+		VolumeID:       volume.VolumeID,
+		Pool:           pool.Name,
+		ProtectionMode: "replication",
+		ExpectedCount:  expectedCount,
+	}
+
+	// Check availability of each node in the placement map.
+	for _, nodeID := range placement.Nodes {
+		if c.nodeChecker.IsNodeAvailable(ctx, nodeID) {
+			result.AvailableNodes = append(result.AvailableNodes, nodeID)
+		} else {
+			result.FailedNodes = append(result.FailedNodes, nodeID)
+		}
+	}
+
+	result.ActualCount = len(result.AvailableNodes)
+
+	// Determine compliance status.
+	if result.ActualCount == 0 {
+		result.Status = StatusUnavailable
+	} else if result.ActualCount < expectedCount {
+		result.Status = StatusUnderReplicated
+	} else {
+		result.Status = StatusCompliant
+	}
+
+	return result, nil
+}
+
+// CheckChunkWithChecksum verifies chunk compliance including checksum validation.
+// It attempts to read the chunk from an available node and verify its checksum.
+func (c *ReplicationChecker) CheckChunkWithChecksum(ctx context.Context, chunkID string, volume *VolumeMeta, pool *v1alpha1.StoragePool, chunkReader ChunkReader) (*ChunkComplianceResult, error) {
+	result, err := c.CheckChunk(ctx, chunkID, volume, pool)
+	if err != nil {
+		return nil, err
+	}
+
+	// If no replicas are available, we can't verify checksum.
+	if len(result.AvailableNodes) == 0 {
+		return result, nil
+	}
+
+	// Try to read and verify the chunk from an available node.
+	for _, nodeID := range result.AvailableNodes {
+		corrupted, readErr := chunkReader.VerifyChunkChecksum(ctx, nodeID, chunkID)
+		if readErr != nil {
+			// If we can't read from this node, consider it failed for checksum purposes.
+			continue
+		}
+		if corrupted {
+			result.Status = StatusCorrupted
+			return result, nil
+		}
+		// Found a valid replica with correct checksum.
+		break
+	}
+
+	return result, nil
+}
+
+// ChunkReader can read chunks and verify their checksums.
+type ChunkReader interface {
+	// VerifyChunkChecksum reads the chunk and returns true if the checksum is invalid.
+	// Returns an error if the chunk cannot be read.
+	VerifyChunkChecksum(ctx context.Context, nodeID, chunkID string) (corrupted bool, err error)
+}
+
+// RepairChunk replicates a chunk to a new node to restore compliance.
+func (c *ReplicationChecker) RepairChunk(ctx context.Context, chunkID string, sourceNode, destNode string, replicator ChunkReplicator) error {
+	if replicator == nil {
+		return fmt.Errorf("chunk replicator is nil")
+	}
+	return replicator.ReplicateChunk(ctx, chunkID, sourceNode, destNode)
+}
+
+// ChunkReplicator can replicate a chunk from one node to another.
+type ChunkReplicator interface {
+	ReplicateChunk(ctx context.Context, chunkID, sourceNode, destNode string) error
+}

--- a/internal/policy/runnable.go
+++ b/internal/policy/runnable.go
@@ -1,0 +1,193 @@
+package policy
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/piwi3910/novastor/api/v1alpha1"
+	"github.com/piwi3910/novastor/internal/logging"
+	"go.uber.org/zap"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/client-go/tools/record"
+)
+
+// PolicyEngineRunnable wraps the policy engine and reconciler as a controller-runtime Runnable.
+type PolicyEngineRunnable struct {
+	engine        *PolicyEngine
+	reconciler    *Reconciler
+	metrics       *MetricsReporter
+	scanInterval  time.Duration
+	repairEnabled bool
+	eventRecorder record.EventRecorder
+}
+
+// NewPolicyEngineRunnable creates a new PolicyEngineRunnable.
+func NewPolicyEngineRunnable(
+	metaClient MetadataClient,
+	poolLookup PoolLookup,
+	nodeChecker NodeAvailabilityChecker,
+	chunkReplicator ChunkReplicator,
+	shardReplicator ShardReplicator,
+	eventRecorder record.EventRecorder,
+	scanInterval time.Duration,
+	repairEnabled bool,
+) *PolicyEngineRunnable {
+	engine := NewPolicyEngine(metaClient, nodeChecker)
+	reconciler := NewReconciler(metaClient, nodeChecker, poolLookup)
+	reconciler.SetChunkReplicator(chunkReplicator)
+	reconciler.SetShardReplicator(shardReplicator)
+
+	return &PolicyEngineRunnable{
+		engine:        engine,
+		reconciler:    reconciler,
+		metrics:       NewMetricsReporter(),
+		scanInterval:  scanInterval,
+		repairEnabled: repairEnabled,
+		eventRecorder: eventRecorder,
+	}
+}
+
+// Start implements the manager.Runnable interface.
+func (r *PolicyEngineRunnable) Start(ctx context.Context) error {
+	logger := logging.L.Named("policy-engine")
+
+	ticker := time.NewTicker(r.scanInterval)
+	defer ticker.Stop()
+
+	logger.Info("policy engine started",
+		zap.Duration("scanInterval", r.scanInterval),
+		zap.Bool("repairEnabled", r.repairEnabled),
+	)
+
+	// Run initial scan immediately
+	r.runCycle(ctx, logger)
+
+	for {
+		select {
+		case <-ctx.Done():
+			logger.Info("policy engine stopping")
+			return nil
+		case <-ticker.C:
+			r.runCycle(ctx, logger)
+		}
+	}
+}
+
+// runCycle performs one full cycle: scan for compliance issues and optionally repair.
+func (r *PolicyEngineRunnable) runCycle(ctx context.Context, logger *zap.Logger) {
+	// Phase 1: Compliance scan
+	scanStart := r.metrics.ReportScanStart("full")
+
+	reports, err := r.engine.CheckAllPoolsCompliance(ctx, r.reconciler.getPoolLookup())
+	if err != nil {
+		logger.Error("compliance scan failed", zap.Error(err))
+		return
+	}
+
+	r.metrics.ReportScanComplete("full", scanStart)
+
+	// Phase 2: Report metrics
+	for poolName, report := range reports {
+		r.metrics.ReportPoolCompliance(poolName, report.ProtectionMode, report.IsCompliant)
+		r.metrics.ReportChunkViolations(
+			poolName,
+			report.CompliantChunks,
+			report.UnderReplicatedChunks,
+			report.UnavailableChunks,
+			report.CorruptedChunks,
+		)
+
+		// Record events for non-compliant pools
+		if !report.IsCompliant {
+			logger.Warn("pool not compliant",
+				zap.String("pool", poolName),
+				zap.Int("underReplicated", report.UnderReplicatedChunks),
+				zap.Int("unavailable", report.UnavailableChunks),
+				zap.Int("corrupted", report.CorruptedChunks),
+			)
+		}
+	}
+
+	// Phase 3: Enqueue repair tasks
+	summary, err := r.reconciler.ScanAndEnqueue(ctx)
+	if err != nil {
+		logger.Error("failed to enqueue repair tasks", zap.Error(err))
+		return
+	}
+
+	r.metrics.ReportRepairQueued(r.reconciler.QueueSize())
+
+	logger.Info("compliance scan completed",
+		zap.Int("pools", len(reports)),
+		zap.Duration("duration", summary.Duration),
+		zap.Int("tasksQueued", summary.TasksQueued),
+		zap.Int("queueSize", r.reconciler.QueueSize()),
+	)
+
+	// Phase 4: Process repair queue
+	if r.repairEnabled && r.reconciler.QueueSize() > 0 {
+		repairStart := time.Now()
+
+		if err := r.reconciler.ProcessQueue(ctx); err != nil {
+			logger.Error("repair queue processing failed", zap.Error(err))
+		}
+
+		repairDuration := time.Since(repairStart)
+		logger.Info("repair cycle completed",
+			zap.Duration("duration", repairDuration),
+			zap.Int64("completed", r.reconciler.CompletedRepairs()),
+			zap.Int64("failed", r.reconciler.FailedRepairs()),
+		)
+	}
+}
+
+// Engine returns the underlying PolicyEngine for external queries.
+func (r *PolicyEngineRunnable) Engine() *PolicyEngine {
+	return r.engine
+}
+
+// Reconciler returns the underlying Reconciler for status queries.
+func (r *PolicyEngineRunnable) Reconciler() *Reconciler {
+	return r.reconciler
+}
+
+// TriggerScan forces an immediate compliance scan and repair cycle.
+// This is useful for on-demand checks triggered by external events.
+func (r *PolicyEngineRunnable) TriggerScan(ctx context.Context) error {
+	logger := logging.L.Named("policy-engine")
+	logger.Info("triggering manual compliance scan")
+	r.runCycle(ctx, logger)
+	return nil
+}
+
+// PoolComplianceStatus returns the current compliance status for a specific pool.
+func (r *PolicyEngineRunnable) PoolComplianceStatus(ctx context.Context, poolName string) (*PoolComplianceReport, error) {
+	pool, err := r.reconciler.getPoolLookup().GetPool(ctx, poolName)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			return nil, fmt.Errorf("pool %s not found", poolName)
+		}
+		return nil, err
+	}
+
+	return r.engine.CheckPoolCompliance(ctx, pool)
+}
+
+// VolumeComplianceStatus returns the current compliance status for a specific volume.
+func (r *PolicyEngineRunnable) VolumeComplianceStatus(ctx context.Context, volumeID string, pool *v1alpha1.StoragePool) (*VolumeComplianceReport, error) {
+	volume, err := r.engine.metaClient.GetVolumeMeta(ctx, volumeID)
+	if err != nil {
+		return nil, fmt.Errorf("getting volume metadata: %w", err)
+	}
+
+	return r.engine.CheckVolumeCompliance(ctx, volume, pool)
+}
+
+// RepairStatus returns the current status of the repair queue.
+func (r *PolicyEngineRunnable) RepairStatus() (queueSize int, completed int64, failed int64, lastScan time.Time) {
+	return r.reconciler.QueueSize(),
+		r.reconciler.CompletedRepairs(),
+		r.reconciler.FailedRepairs(),
+		r.reconciler.lastScanTime
+}


### PR DESCRIPTION
Implement a policy engine that continuously checks data protection
compliance and automatically reconciles degraded or failed chunks.

## Summary

This PR adds a comprehensive policy engine for NovaStor that:
- Periodically checks all volumes for data protection compliance
- Verifies replica counts for replication-mode chunks
- Verifies shard availability for erasure-coded chunks
- Flags degraded/failed chunks and triggers repair operations
- Reports compliance status via Prometheus metrics

## Components Added

### Core Policy Engine (`internal/policy/compliance.go`)
- `ComplianceStatus` enum: `Compliant`, `UnderReplicated`, `Unavailable`, `Corrupted`
- `ChunkComplianceResult`: Detailed compliance status for individual chunks
- `VolumeComplianceReport`: Summary of compliance for a volume
- `PoolComplianceReport`: Summary of compliance for a storage pool
- `PolicyEngine`: Orchestrates compliance checking across all volumes and pools

### Compliance Checkers
- **`ReplicationChecker`** (`internal/policy/replication_checker.go`): Verifies replication factor compliance
- **`ErasureCodingChecker`** (`internal/policy/erasure_checker.go`): Verifies erasure coding shard compliance

### Reconciliation Engine (`internal/policy/reconciler.go`)
- Scans all pools for non-compliant chunks
- Enqueues repair tasks with priority based on severity
- Coordinates with existing `RecoveryManager` for repairs
- Configurable concurrency limits

### Metrics (`internal/policy/metrics.go`)
- `novastor_policy_pool_compliance_status`: Compliance status per pool
- `novastor_policy_chunk_compliance_violations`: Chunk counts by status
- `novastor_policy_scan_duration_seconds`: Compliance scan timing
- `novastor_policy_repair_*`: Repair operation metrics

### Integration (`internal/policy/controller_integration.go`, `runnable.go`)
- `K8sPoolLookup`: Queries StoragePool resources from Kubernetes
- `K8sNodeAvailabilityChecker`: Checks node readiness via Kubernetes API
- `PolicyEngineRunnable`: Controller-runtime Runnable for deployment

## Configuration

New controller flags:
- `--policy-engine-enabled=true`: Enable policy engine (default: true)
- `--policy-scan-interval=5m`: Interval between compliance scans
- `--policy-repair-enabled=true`: Enable automatic repair (default: true)
- `--policy-repair-concurrency=4`: Max concurrent repair operations

## Test Plan

- [x] Unit tests for `ReplicationChecker`
- [x] Unit tests for `ErasureCodingChecker`
- [x] Unit tests for `PolicyEngine` volume compliance
- [x] Unit tests for `PolicyEngine` pool compliance
- [x] Unit tests for `Reconciler` scan and enqueue
- [x] All tests pass with race detection
- [x] `go vet` passes on all new code

Resolves #35