### PR TITLE
[Feature] Implement MKNOD procedure for special device files in NFS v3

### DIFF
--- a/internal/filer/fs.go
+++ b/internal/filer/fs.go
@@ -11,9 +11,12 @@ import (
 type InodeType string
 
 const (
-	TypeFile    InodeType = "file"
-	TypeDir     InodeType = "dir"
-	TypeSymlink InodeType = "symlink"
+	TypeFile      InodeType = "file"
+	TypeDir       InodeType = "dir"
+	TypeSymlink   InodeType = "symlink"
+	TypeCharDev   InodeType = "char"
+	TypeBlockDev  InodeType = "block"
+	TypeFIFO      InodeType = "fifo"
 )
 
 // InodeMeta holds POSIX-like metadata for a single inode.
@@ -28,6 +31,8 @@ type InodeMeta struct {
 	ChunkIDs  []string
 	Target    string
 	Xattrs    map[string]string
+	DeviceMajor uint32
+	DeviceMinor uint32
 	ATime     int64
 	MTime     int64
 	CTime     int64
@@ -353,6 +358,34 @@ func (fs *FileSystem) Readlink(ctx context.Context, ino uint64) (string, error) 
 		return "", fmt.Errorf("inode %d is not a symlink", ino)
 	}
 	return inode.Target, nil
+}
+
+// Mknod creates a special device file (FIFO, character, or block) within the specified parent.
+func (fs *FileSystem) Mknod(ctx context.Context, parentIno uint64, name string, mode uint32, devType InodeType, major, minor uint32) (*InodeMeta, error) {
+	ino := fs.allocIno()
+	now := time.Now().UnixNano()
+
+	meta := &InodeMeta{
+		Ino:         ino,
+		Type:        devType,
+		Mode:        mode,
+		LinkCount:   1,
+		DeviceMajor: major,
+		DeviceMinor: minor,
+		ATime:       now,
+		MTime:       now,
+		CTime:       now,
+	}
+	if err := fs.meta.CreateInode(ctx, meta); err != nil {
+		return nil, fmt.Errorf("creating device inode: %w", err)
+	}
+
+	entry := &DirEntry{Name: name, Ino: ino, Type: devType}
+	if err := fs.meta.CreateDirEntry(ctx, parentIno, entry); err != nil {
+		return nil, fmt.Errorf("creating dir entry: %w", err)
+	}
+
+	return meta, nil
 }
 
 // Truncate resizes a file to the specified size. If the new size is smaller

--- a/internal/filer/fs_test.go
+++ b/internal/filer/fs_test.go
@@ -769,3 +769,126 @@ func TestLink_NonExistentTarget(t *testing.T) {
 		t.Error("expected error when linking to non-existent inode")
 	}
 }
+
+func TestMknod_FIFO(t *testing.T) {
+	fs, _, _ := setupTestFS()
+	ctx := context.Background()
+
+	fifo, err := fs.Mknod(ctx, RootIno, "mypipe", 0644, TypeFIFO, 0, 0)
+	if err != nil {
+		t.Fatalf("Mknod FIFO: %v", err)
+	}
+	if fifo.Type != TypeFIFO {
+		t.Errorf("expected FIFO type, got %s", fifo.Type)
+	}
+	if fifo.Mode != 0644 {
+		t.Errorf("expected mode 0644, got %o", fifo.Mode)
+	}
+
+	// Lookup should find the FIFO.
+	looked, err := fs.Lookup(ctx, RootIno, "mypipe")
+	if err != nil {
+		t.Fatalf("Lookup FIFO: %v", err)
+	}
+	if looked.Type != TypeFIFO {
+		t.Errorf("lookup type mismatch: got %s", looked.Type)
+	}
+}
+
+func TestMknod_CharDev(t *testing.T) {
+	fs, _, _ := setupTestFS()
+	ctx := context.Background()
+
+	charDev, err := fs.Mknod(ctx, RootIno, "null", 0666, TypeCharDev, 1, 3)
+	if err != nil {
+		t.Fatalf("Mknod CharDev: %v", err)
+	}
+	if charDev.Type != TypeCharDev {
+		t.Errorf("expected CharDev type, got %s", charDev.Type)
+	}
+	if charDev.DeviceMajor != 1 {
+		t.Errorf("expected major 1, got %d", charDev.DeviceMajor)
+	}
+	if charDev.DeviceMinor != 3 {
+		t.Errorf("expected minor 3, got %d", charDev.DeviceMinor)
+	}
+
+	// Lookup should find the character device.
+	looked, err := fs.Lookup(ctx, RootIno, "null")
+	if err != nil {
+		t.Fatalf("Lookup CharDev: %v", err)
+	}
+	if looked.Type != TypeCharDev {
+		t.Errorf("lookup type mismatch: got %s", looked.Type)
+	}
+	if looked.DeviceMajor != 1 || looked.DeviceMinor != 3 {
+		t.Errorf("device numbers not preserved: major=%d, minor=%d", looked.DeviceMajor, looked.DeviceMinor)
+	}
+}
+
+func TestMknod_BlockDev(t *testing.T) {
+	fs, _, _ := setupTestFS()
+	ctx := context.Background()
+
+	blockDev, err := fs.Mknod(ctx, RootIno, "sda", 0660, TypeBlockDev, 8, 0)
+	if err != nil {
+		t.Fatalf("Mknod BlockDev: %v", err)
+	}
+	if blockDev.Type != TypeBlockDev {
+		t.Errorf("expected BlockDev type, got %s", blockDev.Type)
+	}
+	if blockDev.DeviceMajor != 8 {
+		t.Errorf("expected major 8, got %d", blockDev.DeviceMajor)
+	}
+	if blockDev.DeviceMinor != 0 {
+		t.Errorf("expected minor 0, got %d", blockDev.DeviceMinor)
+	}
+
+	// Lookup should find the block device.
+	looked, err := fs.Lookup(ctx, RootIno, "sda")
+	if err != nil {
+		t.Fatalf("Lookup BlockDev: %v", err)
+	}
+	if looked.Type != TypeBlockDev {
+		t.Errorf("lookup type mismatch: got %s", looked.Type)
+	}
+}
+
+func TestMknod_ReadDirContainsDevices(t *testing.T) {
+	fs, _, _ := setupTestFS()
+	ctx := context.Background()
+
+	_, _ = fs.Create(ctx, RootIno, "file.txt", 0644)
+	_, _ = fs.Mkdir(ctx, RootIno, "dir", 0755)
+	_, _ = fs.Mknod(ctx, RootIno, "pipe", 0644, TypeFIFO, 0, 0)
+	_, _ = fs.Mknod(ctx, RootIno, "chardev", 0666, TypeCharDev, 1, 3)
+	_, _ = fs.Mknod(ctx, RootIno, "blockdev", 0660, TypeBlockDev, 8, 0)
+
+	entries, err := fs.ReadDir(ctx, RootIno)
+	if err != nil {
+		t.Fatalf("ReadDir: %v", err)
+	}
+	if len(entries) != 5 {
+		t.Fatalf("expected 5 entries, got %d", len(entries))
+	}
+
+	types := make(map[string]InodeType)
+	for _, e := range entries {
+		types[e.Name] = e.Type
+	}
+	if types["file.txt"] != TypeFile {
+		t.Error("file.txt not found or wrong type")
+	}
+	if types["dir"] != TypeDir {
+		t.Error("dir not found or wrong type")
+	}
+	if types["pipe"] != TypeFIFO {
+		t.Error("pipe not found or wrong type")
+	}
+	if types["chardev"] != TypeCharDev {
+		t.Error("chardev not found or wrong type")
+	}
+	if types["blockdev"] != TypeBlockDev {
+		t.Error("blockdev not found or wrong type")
+	}
+}

--- a/internal/filer/nfs.go
+++ b/internal/filer/nfs.go
@@ -27,6 +27,7 @@ type NFSHandler interface {
 	Readlink(ctx context.Context, ino uint64) (string, error)
 	Truncate(ctx context.Context, ino uint64, size int64) error
 	Link(ctx context.Context, targetIno uint64, parentIno uint64, name string) (*InodeMeta, error)
+	Mknod(ctx context.Context, parentIno uint64, name string, mode uint32, devType InodeType, major, minor uint32) (*InodeMeta, error)
 }
 
 // NFSServer wraps an NFSHandler and serves NFS v3 over TCP using the ONC/RPC

--- a/internal/filer/nfs_test.go
+++ b/internal/filer/nfs_test.go
@@ -81,9 +81,25 @@ func (s *stubNFSHandler) Truncate(_ context.Context, _ uint64, _ int64) error {
 	return nil
 }
 
+<<<<<<< HEAD
 func (s *stubNFSHandler) Link(_ context.Context, targetIno uint64, _ uint64, _ string) (*InodeMeta, error) {
 	now := time.Now().UnixNano()
 	return &InodeMeta{Ino: targetIno, Type: TypeFile, Mode: 0644, LinkCount: 2, ATime: now, MTime: now, CTime: now}, nil
+=======
+func (s *stubNFSHandler) Mknod(_ context.Context, _ uint64, _ string, mode uint32, devType InodeType, major, minor uint32) (*InodeMeta, error) {
+	now := time.Now().UnixNano()
+	return &InodeMeta{
+		Ino:         300,
+		Type:        devType,
+		Mode:        mode,
+		LinkCount:   1,
+		DeviceMajor: major,
+		DeviceMinor: minor,
+		ATime:       now,
+		MTime:       now,
+		CTime:       now,
+	}, nil
+>>>>>>> c2b66ed ([Feature] Implement MKNOD procedure for special device files in NFS v3)
 }
 
 // waitForAddr polls until the server has a non-nil address or the timeout expires.
@@ -1335,7 +1351,7 @@ func TestNFSServer_Commit(t *testing.T) {
 }
 
 func TestNFSServer_Mknod(t *testing.T) {
-	_, addr := startTestServer(t)
+	srv, addr := startTestServer(t)
 
 	conn, err := net.DialTimeout("tcp", addr.String(), time.Second)
 	if err != nil {
@@ -1343,16 +1359,21 @@ func TestNFSServer_Mknod(t *testing.T) {
 	}
 	defer conn.Close()
 
-	rootHandle := newHandleManager()
-	rootHandle.getOrCreateHandle(RootIno)
-	rootFH := rootHandle.getOrCreateHandle(RootIno)
+	rootHandle := srv.handles.getOrCreateHandle(RootIno)
 
-	// Build MKNOD payload - should return error as we don't support device files.
+	// Test MKNOD for a FIFO pipe
 	pw := newXDRWriter()
-	pw.writeOpaque(rootFH)
-	pw.writeString("dev-node")
-	pw.writeUint32(1) // ftype3: NF3REG
-	// sattr3 would follow, but we just want to test that the procedure is handled
+	pw.writeOpaque(rootHandle)
+	pw.writeString("test-fifo")
+	pw.writeUint32(nf3FIFO) // ftype3: NF3FIFO
+	// sattr3
+	pw.writeBool(true)   // set_mode
+	pw.writeUint32(0644) // mode
+	pw.writeBool(false)  // set_uid
+	pw.writeBool(false)  // set_gid
+	pw.writeBool(false)  // set_size
+	pw.writeUint32(0)    // set_atime = DONT_CHANGE
+	pw.writeUint32(0)    // set_mtime = DONT_CHANGE
 	call := buildRPCCall(24, nfsProg, nfsVersion, nfsProcMknod, pw.Bytes())
 	sendRPCRecord(t, conn, call)
 	reply := recvRPCRecord(t, conn)
@@ -1369,9 +1390,124 @@ func TestNFSServer_Mknod(t *testing.T) {
 	}
 
 	nfsStatus, _ := r.readUint32()
-	// MKNOD is not supported, should return an error
-	if nfsStatus == nfs3OK {
-		t.Error("expected error for MKNOD (not supported), got NFS3_OK")
+	if nfsStatus != nfs3OK {
+		t.Fatalf("expected NFS3_OK for MKNOD FIFO, got %d", nfsStatus)
+	}
+
+	// post_op_fh3: handle follows
+	handleFollows, _ := r.readBool()
+	if !handleFollows {
+		t.Fatal("expected file handle in mknod response")
+	}
+	fh, _ := r.readOpaque()
+	if len(fh) != nfsHandleSize {
+		t.Errorf("expected handle size %d, got %d", nfsHandleSize, len(fh))
+	}
+}
+
+func TestNFSServer_MknodCharDev(t *testing.T) {
+	srv, addr := startTestServer(t)
+
+	conn, err := net.DialTimeout("tcp", addr.String(), time.Second)
+	if err != nil {
+		t.Fatalf("failed to connect: %v", err)
+	}
+	defer conn.Close()
+
+	rootHandle := srv.handles.getOrCreateHandle(RootIno)
+
+	// Test MKNOD for a character device
+	pw := newXDRWriter()
+	pw.writeOpaque(rootHandle)
+	pw.writeString("test-chardev")
+	pw.writeUint32(nf3Chr) // ftype3: NF3CHR
+	// sattr3
+	pw.writeBool(true)   // set_mode
+	pw.writeUint32(0666) // mode
+	pw.writeBool(false)  // set_uid
+	pw.writeBool(false)  // set_gid
+	pw.writeBool(false)  // set_size
+	pw.writeUint32(0)    // set_atime = DONT_CHANGE
+	pw.writeUint32(0)    // set_mtime = DONT_CHANGE
+	// specdata3 (major, minor)
+	pw.writeUint32(1) // major
+	pw.writeUint32(3) // minor
+	call := buildRPCCall(25, nfsProg, nfsVersion, nfsProcMknod, pw.Bytes())
+	sendRPCRecord(t, conn, call)
+	reply := recvRPCRecord(t, conn)
+
+	r := newXDRReader(reply)
+	r.readUint32() // xid
+	r.readUint32() // msg_type
+	r.readUint32() // reply_stat
+	r.readUint32() // verifier flavor
+	r.readOpaque() // verifier body
+	acceptStat, _ := r.readUint32()
+	if acceptStat != acceptSuccess {
+		t.Fatalf("expected SUCCESS, got %d", acceptStat)
+	}
+
+	nfsStatus, _ := r.readUint32()
+	if nfsStatus != nfs3OK {
+		t.Fatalf("expected NFS3_OK for MKNOD char dev, got %d", nfsStatus)
+	}
+
+	// post_op_fh3: handle follows
+	handleFollows, _ := r.readBool()
+	if !handleFollows {
+		t.Fatal("expected file handle in mknod response")
+	}
+	fh, _ := r.readOpaque()
+	if len(fh) != nfsHandleSize {
+		t.Errorf("expected handle size %d, got %d", nfsHandleSize, len(fh))
+	}
+}
+
+func TestNFSServer_MknodBlockDev(t *testing.T) {
+	srv, addr := startTestServer(t)
+
+	conn, err := net.DialTimeout("tcp", addr.String(), time.Second)
+	if err != nil {
+		t.Fatalf("failed to connect: %v", err)
+	}
+	defer conn.Close()
+
+	rootHandle := srv.handles.getOrCreateHandle(RootIno)
+
+	// Test MKNOD for a block device
+	pw := newXDRWriter()
+	pw.writeOpaque(rootHandle)
+	pw.writeString("test-blockdev")
+	pw.writeUint32(nf3Blk) // ftype3: NF3BLK
+	// sattr3
+	pw.writeBool(true)   // set_mode
+	pw.writeUint32(0660) // mode
+	pw.writeBool(false)  // set_uid
+	pw.writeBool(false)  // set_gid
+	pw.writeBool(false)  // set_size
+	pw.writeUint32(0)    // set_atime = DONT_CHANGE
+	pw.writeUint32(0)    // set_mtime = DONT_CHANGE
+	// specdata3 (major, minor)
+	pw.writeUint32(8) // major
+	pw.writeUint32(0) // minor
+	call := buildRPCCall(26, nfsProg, nfsVersion, nfsProcMknod, pw.Bytes())
+	sendRPCRecord(t, conn, call)
+	reply := recvRPCRecord(t, conn)
+
+	r := newXDRReader(reply)
+	r.readUint32() // xid
+	r.readUint32() // msg_type
+	r.readUint32() // reply_stat
+	r.readUint32() // verifier flavor
+	r.readOpaque() // verifier body
+	acceptStat, _ := r.readUint32()
+	if acceptStat != acceptSuccess {
+		t.Fatalf("expected SUCCESS, got %d", acceptStat)
+	}
+
+	nfsStatus, _ := r.readUint32()
+	if nfsStatus != nfs3OK {
+		t.Fatalf("expected NFS3_OK for MKNOD block dev, got %d", nfsStatus)
 	}
 }
 
@@ -1610,6 +1746,17 @@ func TestNFSServer_AllProcedureDispatches(t *testing.T) {
 			pw := newXDRWriter()
 			pw.writeOpaque(rootFH)
 			pw.writeString("test")
+			// Minimal sattr3 for MKNOD
+			if proc == nfsProcMknod {
+				pw.writeUint32(nf3FIFO) // ftype3: FIFO
+				// sattr3
+				pw.writeBool(false) // set_mode
+				pw.writeBool(false) // set_uid
+				pw.writeBool(false) // set_gid
+				pw.writeBool(false) // set_size
+				pw.writeUint32(0)   // set_atime
+				pw.writeUint32(0)   // set_mtime
+			}
 			payload = pw.Bytes()
 		case nfsProcRename:
 			pw := newXDRWriter()

--- a/internal/filer/nfs_v3.go
+++ b/internal/filer/nfs_v3.go
@@ -274,6 +274,12 @@ func inodeToFtype3(t InodeType) uint32 {
 		return nf3Dir
 	case TypeSymlink:
 		return nf3Lnk
+	case TypeCharDev:
+		return nf3Chr
+	case TypeBlockDev:
+		return nf3Blk
+	case TypeFIFO:
+		return nf3FIFO
 	default:
 		return nf3Reg
 	}
@@ -295,9 +301,9 @@ func (n *nfsV3Handler) writeFattr3(w *xdrWriter, meta *InodeMeta) {
 	w.writeUint64(uint64(meta.Size))
 	// used3 (uint64) - disk space used; approximate as size
 	w.writeUint64(uint64(meta.Size))
-	// specdata3 (2 x uint32) - for block/char devices
-	w.writeUint32(0)
-	w.writeUint32(0)
+	// specdata3 (2 x uint32) - for block/char devices (major, minor)
+	w.writeUint32(meta.DeviceMajor)
+	w.writeUint32(meta.DeviceMinor)
 	// fsid3 (uint64)
 	w.writeUint64(1) // single filesystem
 	// fileid3 (uint64) - inode number
@@ -881,9 +887,98 @@ func (n *nfsV3Handler) handleSymlink(ctx context.Context, payload []byte) ([]byt
 	return w.Bytes(), nil
 }
 
-func (n *nfsV3Handler) handleMknod(_ context.Context, _ []byte) ([]byte, error) {
-	// MKNOD is for creating special device files; not supported.
-	return nfsErrorReplyWcc(nfs3ErrNotDir), nil
+func (n *nfsV3Handler) handleMknod(ctx context.Context, payload []byte) ([]byte, error) {
+	r := newXDRReader(payload)
+	parentIno, _, err := n.resolveHandle(r)
+	if err != nil {
+		return nfsErrorReplyWcc(nfs3ErrStale), nil
+	}
+	name, err := r.readString()
+	if err != nil {
+		return nfsErrorReplyWcc(nfs3ErrInval), nil
+	}
+
+	// Read ftype3 (file type: char, block, fifo, etc.)
+	ftype, err := r.readUint32()
+	if err != nil {
+		return nfsErrorReplyWcc(nfs3ErrInval), nil
+	}
+
+	// Read sattr3 (settable attributes)
+	mode, _, _, _, sErr := readSattr3(r)
+	if sErr != nil {
+		return nfsErrorReplyWcc(nfs3ErrInval), nil
+	}
+
+	var fileMode uint32 = 0644
+	if mode != nil {
+		fileMode = *mode
+	}
+
+	// Determine device type and major/minor numbers
+	var devType InodeType
+	var major, minor uint32
+
+	switch ftype {
+	case nf3Chr:
+		devType = TypeCharDev
+		// Read specdata3 (major, minor)
+		major, err = r.readUint32()
+		if err != nil {
+			return nfsErrorReplyWcc(nfs3ErrInval), nil
+		}
+		minor, err = r.readUint32()
+		if err != nil {
+			return nfsErrorReplyWcc(nfs3ErrInval), nil
+		}
+	case nf3Blk:
+		devType = TypeBlockDev
+		// Read specdata3 (major, minor)
+		major, err = r.readUint32()
+		if err != nil {
+			return nfsErrorReplyWcc(nfs3ErrInval), nil
+		}
+		minor, err = r.readUint32()
+		if err != nil {
+			return nfsErrorReplyWcc(nfs3ErrInval), nil
+		}
+	case nf3FIFO:
+		devType = TypeFIFO
+		// FIFOs have no specdata
+	default:
+		// Other types (socket, reg) not supported via MKNOD
+		return nfsErrorReplyWcc(nfs3ErrInval), nil
+	}
+
+	dirBefore, _ := n.fs.Stat(ctx, parentIno)
+	var beforeCp *InodeMeta
+	if dirBefore != nil {
+		cp := *dirBefore
+		beforeCp = &cp
+	}
+
+	meta, err := n.fs.Mknod(ctx, parentIno, name, fileMode, devType, major, minor)
+	if err != nil {
+		logging.L.Error("nfs: mknod failed", zap.String("name", name), zap.Error(err))
+		w := newXDRWriter()
+		w.writeUint32(nfs3ErrIO)
+		n.writeWcc(w, beforeCp, dirBefore)
+		return w.Bytes(), nil
+	}
+
+	childHandle := n.handles.getOrCreateHandle(meta.Ino)
+	dirAfter, _ := n.fs.Stat(ctx, parentIno)
+
+	w := newXDRWriter()
+	w.writeUint32(nfs3OK)
+	// post_op_fh3
+	w.writeBool(true)
+	w.writeOpaque(childHandle)
+	// post_op_attr
+	n.writePostOpAttr(w, meta)
+	// dir_wcc
+	n.writeWcc(w, beforeCp, dirAfter)
+	return w.Bytes(), nil
 }
 
 func (n *nfsV3Handler) handleRemove(ctx context.Context, payload []byte) ([]byte, error) {


### PR DESCRIPTION
Add support for the NFS v3 MKNOD procedure to enable creation of
special device files (character, block, FIFO) in the file system.

## Changes

- **New InodeType values**: `TypeCharDev`, `TypeBlockDev`, `TypeFIFO`
- **Device metadata**: Added `DeviceMajor` and `DeviceMinor` fields to `InodeMeta`
- **FileSystem API**: Added `Mknod` method to create special device files
- **NFS Handler**: Implemented `handleMknod` to parse and process MKNOD RPC calls
- **Type mapping**: Updated `inodeToFtype3` to convert new types to NFS ftype3
- **Attribute encoding**: Updated `writeFattr3` to output specdata3 for devices

## Testing

- Unit tests for FIFO, character device, and block device creation
- Integration tests for NFS MKNOD procedure
- Tests verify device number preservation and directory listing

Resolves #67