### PR TITLE
[Feature] Implement file size truncation in NFS v3 SETATTR

### DIFF
--- a/internal/filer/fs.go
+++ b/internal/filer/fs.go
@@ -354,3 +354,62 @@ func (fs *FileSystem) Readlink(ctx context.Context, ino uint64) (string, error) 
 	}
 	return inode.Target, nil
 }
+
+// Truncate resizes a file to the specified size. If the new size is smaller
+// than the current size, data beyond the new size is discarded. If the new
+// size is larger, the file is extended with zeros. This operation updates
+// the chunk metadata to reflect the new file size.
+func (fs *FileSystem) Truncate(ctx context.Context, ino uint64, size int64) error {
+	if size < 0 {
+		return fmt.Errorf("invalid size %d: must be non-negative", size)
+	}
+
+	inode, err := fs.meta.GetInode(ctx, ino)
+	if err != nil {
+		return fmt.Errorf("getting inode %d: %w", ino, err)
+	}
+	if inode.Type != TypeFile {
+		return fmt.Errorf("inode %d is not a file", ino)
+	}
+
+	// If the size is the same, nothing to do.
+	if size == inode.Size {
+		return nil
+	}
+
+	// If shrinking, we need to read the data up to the new size and write new chunks.
+	// If growing, we need to read existing data, pad with zeros, and write new chunks.
+	var existing []byte
+	if len(inode.ChunkIDs) > 0 && inode.Size > 0 {
+		readSize := inode.Size
+		if size < readSize {
+			readSize = size
+		}
+		existing, err = fs.chunks.ReadChunks(ctx, inode.ChunkIDs, 0, readSize)
+		if err != nil {
+			return fmt.Errorf("reading existing chunks: %w", err)
+		}
+	}
+
+	// Build the new content buffer.
+	buf := make([]byte, size)
+	copy(buf, existing)
+
+	// Write new chunks.
+	chunkIDs, err := fs.chunks.WriteChunks(ctx, buf)
+	if err != nil {
+		return fmt.Errorf("writing chunks: %w", err)
+	}
+
+	// Update inode.
+	now := time.Now().UnixNano()
+	inode.ChunkIDs = chunkIDs
+	inode.Size = size
+	inode.MTime = now
+	inode.CTime = now
+	if err := fs.meta.UpdateInode(ctx, inode); err != nil {
+		return fmt.Errorf("updating inode: %w", err)
+	}
+
+	return nil
+}

--- a/internal/filer/fs_test.go
+++ b/internal/filer/fs_test.go
@@ -464,3 +464,104 @@ func TestSymlink(t *testing.T) {
 		t.Errorf("lookup type mismatch: got %s", looked.Type)
 	}
 }
+
+func TestTruncate(t *testing.T) {
+	fs, _, _ := setupTestFS()
+	ctx := context.Background()
+
+	// Create a file with some data.
+	file, err := fs.Create(ctx, RootIno, "data.bin", 0644)
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	payload := []byte("Hello, NovaStor! This is some test data.")
+	_, err = fs.Write(ctx, file.Ino, 0, payload)
+	if err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+
+	// Verify initial size.
+	meta, err := fs.Stat(ctx, file.Ino)
+	if err != nil {
+		t.Fatalf("Stat: %v", err)
+	}
+	initialSize := meta.Size
+	if initialSize != int64(len(payload)) {
+		t.Fatalf("initial size mismatch: got %d, want %d", initialSize, len(payload))
+	}
+
+	// Truncate to smaller size.
+	newSize := int64(10)
+	if err := fs.Truncate(ctx, file.Ino, newSize); err != nil {
+		t.Fatalf("Truncate: %v", err)
+	}
+
+	// Verify truncated size.
+	meta, err = fs.Stat(ctx, file.Ino)
+	if err != nil {
+		t.Fatalf("Stat after truncate: %v", err)
+	}
+	if meta.Size != newSize {
+		t.Errorf("size after truncate: got %d, want %d", meta.Size, newSize)
+	}
+
+	// Verify data was truncated.
+	data, err := fs.Read(ctx, file.Ino, 0, 100)
+	if err != nil {
+		t.Fatalf("Read: %v", err)
+	}
+	expectedData := payload[:newSize]
+	if string(data) != string(expectedData) {
+		t.Errorf("data after truncate: got %q, want %q", data, expectedData)
+	}
+
+	// Truncate to zero.
+	if err := fs.Truncate(ctx, file.Ino, 0); err != nil {
+		t.Fatalf("Truncate to zero: %v", err)
+	}
+
+	meta, err = fs.Stat(ctx, file.Ino)
+	if err != nil {
+		t.Fatalf("Stat after truncate to zero: %v", err)
+	}
+	if meta.Size != 0 {
+		t.Errorf("size after truncate to zero: got %d, want 0", meta.Size)
+	}
+
+	data, err = fs.Read(ctx, file.Ino, 0, 100)
+	if err != nil {
+		t.Fatalf("Read after truncate to zero: %v", err)
+	}
+	if len(data) != 0 {
+		t.Errorf("data after truncate to zero: got %d bytes, want 0", len(data))
+	}
+
+	// Truncate to larger size (extend with zeros).
+	extendedSize := int64(20)
+	if err := fs.Truncate(ctx, file.Ino, extendedSize); err != nil {
+		t.Fatalf("Truncate extend: %v", err)
+	}
+
+	meta, err = fs.Stat(ctx, file.Ino)
+	if err != nil {
+		t.Fatalf("Stat after extend: %v", err)
+	}
+	if meta.Size != extendedSize {
+		t.Errorf("size after extend: got %d, want %d", meta.Size, extendedSize)
+	}
+
+	data, err = fs.Read(ctx, file.Ino, 0, 100)
+	if err != nil {
+		t.Fatalf("Read after extend: %v", err)
+	}
+	if int64(len(data)) != extendedSize {
+		t.Errorf("data length after extend: got %d, want %d", len(data), extendedSize)
+	}
+	// All bytes should be zero since we truncated to 0 first.
+	for i, b := range data {
+		if b != 0 {
+			t.Errorf("data[%d] after extend: got %d, want 0", i, b)
+		}
+	}
+}

--- a/internal/filer/nfs.go
+++ b/internal/filer/nfs.go
@@ -25,6 +25,7 @@ type NFSHandler interface {
 	Rename(ctx context.Context, oldParent uint64, oldName string, newParent uint64, newName string) error
 	Symlink(ctx context.Context, parentIno uint64, name string, target string) (*InodeMeta, error)
 	Readlink(ctx context.Context, ino uint64) (string, error)
+	Truncate(ctx context.Context, ino uint64, size int64) error
 }
 
 // NFSServer wraps an NFSHandler and serves NFS v3 over TCP using the ONC/RPC

--- a/internal/filer/nfs_test.go
+++ b/internal/filer/nfs_test.go
@@ -3,7 +3,9 @@ package filer
 import (
 	"context"
 	"encoding/binary"
+	"fmt"
 	"net"
+	"sync"
 	"testing"
 	"time"
 )
@@ -69,6 +71,10 @@ func (s *stubNFSHandler) Symlink(_ context.Context, _ uint64, _ string, target s
 
 func (s *stubNFSHandler) Readlink(_ context.Context, _ uint64) (string, error) {
 	return "/some/target", nil
+}
+
+func (s *stubNFSHandler) Truncate(_ context.Context, _ uint64, _ int64) error {
+	return nil
 }
 
 // waitForAddr polls until the server has a non-nil address or the timeout expires.
@@ -1527,5 +1533,521 @@ func TestNFSServer_AllProcedureDispatches(t *testing.T) {
 		}
 
 		conn.Close()
+	}
+}
+
+// truncationTestHandler implements NFSHandler with a real in-memory file
+// that supports truncation for testing.
+type truncationTestHandler struct {
+	mu       sync.Mutex
+	files    map[uint64][]byte
+	nextIno  uint64
+	rootMeta *InodeMeta
+}
+
+func newTruncationTestHandler() *truncationTestHandler {
+	now := time.Now().UnixNano()
+	return &truncationTestHandler{
+		files: make(map[uint64][]byte),
+		nextIno: 2,
+		rootMeta: &InodeMeta{Ino: 1, Type: TypeDir, Mode: 0755, LinkCount: 2, ATime: now, MTime: now, CTime: now},
+	}
+}
+
+func (h *truncationTestHandler) Stat(_ context.Context, ino uint64) (*InodeMeta, error) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	if ino == 1 {
+		return h.rootMeta, nil
+	}
+	data, ok := h.files[ino]
+	if !ok {
+		return nil, fmt.Errorf("no such inode")
+	}
+	now := time.Now().UnixNano()
+	return &InodeMeta{Ino: ino, Type: TypeFile, Mode: 0644, Size: int64(len(data)), LinkCount: 1, ATime: now, MTime: now, CTime: now}, nil
+}
+
+func (h *truncationTestHandler) Lookup(_ context.Context, parentIno uint64, name string) (*InodeMeta, error) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	if parentIno != 1 {
+		return nil, fmt.Errorf("not found")
+	}
+	// For testing, name "file1" maps to inode 2, "file2" to inode 3
+	ino := uint64(0)
+	if name == "file1" {
+		ino = 2
+	} else if name == "file2" {
+		ino = 3
+	}
+	if ino == 0 {
+		return nil, fmt.Errorf("not found")
+	}
+	data, ok := h.files[ino]
+	if !ok {
+		// Create empty file on lookup
+		h.files[ino] = []byte{}
+		data = []byte{}
+	}
+	now := time.Now().UnixNano()
+	return &InodeMeta{Ino: ino, Type: TypeFile, Mode: 0644, Size: int64(len(data)), LinkCount: 1, ATime: now, MTime: now, CTime: now}, nil
+}
+
+func (h *truncationTestHandler) Mkdir(_ context.Context, _ uint64, _ string, _ uint32) (*InodeMeta, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+
+func (h *truncationTestHandler) Create(_ context.Context, _ uint64, _ string, _ uint32) (*InodeMeta, error) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	ino := h.nextIno
+	h.nextIno++
+	h.files[ino] = []byte{}
+	now := time.Now().UnixNano()
+	return &InodeMeta{Ino: ino, Type: TypeFile, Mode: 0644, Size: 0, LinkCount: 1, ATime: now, MTime: now, CTime: now}, nil
+}
+
+func (h *truncationTestHandler) Unlink(_ context.Context, _ uint64, _ string) error {
+	return nil
+}
+
+func (h *truncationTestHandler) Rmdir(_ context.Context, _ uint64, _ string) error {
+	return nil
+}
+
+func (h *truncationTestHandler) ReadDir(_ context.Context, _ uint64) ([]*DirEntry, error) {
+	return []*DirEntry{}, nil
+}
+
+func (h *truncationTestHandler) Read(_ context.Context, ino uint64, offset, length int64) ([]byte, error) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	data, ok := h.files[ino]
+	if !ok {
+		return nil, fmt.Errorf("no such file")
+	}
+	if offset >= int64(len(data)) {
+		return []byte{}, nil
+	}
+	end := offset + length
+	if end > int64(len(data)) {
+		end = int64(len(data))
+	}
+	return data[offset:end], nil
+}
+
+func (h *truncationTestHandler) Write(_ context.Context, ino uint64, offset int64, data []byte) (int, error) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	fileData, ok := h.files[ino]
+	if !ok {
+		return 0, fmt.Errorf("no such file")
+	}
+	// Extend file if needed
+	newSize := offset + int64(len(data))
+	if newSize > int64(len(fileData)) {
+		newData := make([]byte, newSize)
+		copy(newData, fileData)
+		fileData = newData
+	}
+	copy(fileData[offset:], data)
+	h.files[ino] = fileData
+	return len(data), nil
+}
+
+func (h *truncationTestHandler) Rename(_ context.Context, _ uint64, _ string, _ uint64, _ string) error {
+	return nil
+}
+
+func (h *truncationTestHandler) Symlink(_ context.Context, _ uint64, _ string, _ string) (*InodeMeta, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+
+func (h *truncationTestHandler) Readlink(_ context.Context, _ uint64) (string, error) {
+	return "", fmt.Errorf("not implemented")
+}
+
+func (h *truncationTestHandler) Truncate(_ context.Context, ino uint64, size int64) error {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	_, ok := h.files[ino]
+	if !ok {
+		return fmt.Errorf("no such file")
+	}
+	if size < 0 {
+		return fmt.Errorf("invalid size")
+	}
+	newData := make([]byte, size)
+	copy(newData, h.files[ino])
+	h.files[ino] = newData
+	return nil
+}
+
+// TestNFSServer_SetattrTruncateToZero tests truncating a file to size 0.
+func TestNFSServer_SetattrTruncateToZero(t *testing.T) {
+	handler := newTruncationTestHandler()
+	// Pre-populate a file with content
+	handler.files[2] = []byte("hello world, this is some data")
+
+	srv := NewNFSServer(handler, nil)
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- srv.Serve("127.0.0.1:0")
+	}()
+
+	addr := waitForAddr(srv, 2*time.Second)
+	if addr == nil {
+		t.Fatal("server did not start listening within timeout")
+	}
+	t.Cleanup(func() {
+		srv.Stop()
+		<-errCh
+	})
+
+	conn, err := net.DialTimeout("tcp", addr.String(), time.Second)
+	if err != nil {
+		t.Fatalf("failed to connect: %v", err)
+	}
+	defer conn.Close()
+
+	fileHandle := srv.handles.getOrCreateHandle(2)
+
+	// Build SETATTR payload to truncate to size 0.
+	pw := newXDRWriter()
+	pw.writeOpaque(fileHandle)
+	// sattr3
+	pw.writeBool(false)  // set_mode
+	pw.writeBool(false)  // set_uid
+	pw.writeBool(false)  // set_gid
+	pw.writeBool(true)   // set_size = true
+	pw.writeUint64(0)    // new size = 0
+	pw.writeUint32(0)    // set_atime = DONT_CHANGE
+	pw.writeUint32(0)    // set_mtime = DONT_CHANGE
+	// sattrguard3 - check flag (false = no check)
+	pw.writeBool(false)
+
+	call := buildRPCCall(1, nfsProg, nfsVersion, nfsProcSetattr, pw.Bytes())
+	sendRPCRecord(t, conn, call)
+	reply := recvRPCRecord(t, conn)
+
+	r := newXDRReader(reply)
+	r.readUint32() // xid
+	r.readUint32() // msg_type
+	r.readUint32() // reply_stat
+	r.readUint32() // verifier flavor
+	r.readOpaque() // verifier body
+	acceptStat, _ := r.readUint32()
+	if acceptStat != acceptSuccess {
+		t.Fatalf("expected SUCCESS, got %d", acceptStat)
+	}
+
+	nfsStatus, _ := r.readUint32()
+	if nfsStatus != nfs3OK {
+		t.Fatalf("expected NFS3_OK, got %d", nfsStatus)
+	}
+
+	// Verify the file was truncated
+	data, ok := handler.files[2]
+	if !ok {
+		t.Fatal("file was deleted")
+	}
+	if len(data) != 0 {
+		t.Errorf("expected file size 0, got %d", len(data))
+	}
+}
+
+// TestNFSServer_SetattrTruncateSmaller tests truncating a file to a smaller size.
+func TestNFSServer_SetattrTruncateSmaller(t *testing.T) {
+	handler := newTruncationTestHandler()
+	// Pre-populate a file with content
+	handler.files[2] = []byte("hello world, this is some data") // 31 bytes
+
+	srv := NewNFSServer(handler, nil)
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- srv.Serve("127.0.0.1:0")
+	}()
+
+	addr := waitForAddr(srv, 2*time.Second)
+	if addr == nil {
+		t.Fatal("server did not start listening within timeout")
+	}
+	t.Cleanup(func() {
+		srv.Stop()
+		<-errCh
+	})
+
+	conn, err := net.DialTimeout("tcp", addr.String(), time.Second)
+	if err != nil {
+		t.Fatalf("failed to connect: %v", err)
+	}
+	defer conn.Close()
+
+	fileHandle := srv.handles.getOrCreateHandle(2)
+
+	// Build SETATTR payload to truncate to size 5.
+	pw := newXDRWriter()
+	pw.writeOpaque(fileHandle)
+	// sattr3
+	pw.writeBool(false)  // set_mode
+	pw.writeBool(false)  // set_uid
+	pw.writeBool(false)  // set_gid
+	pw.writeBool(true)   // set_size = true
+	pw.writeUint64(5)    // new size = 5
+	pw.writeUint32(0)    // set_atime = DONT_CHANGE
+	pw.writeUint32(0)    // set_mtime = DONT_CHANGE
+	// sattrguard3
+	pw.writeBool(false)
+
+	call := buildRPCCall(1, nfsProg, nfsVersion, nfsProcSetattr, pw.Bytes())
+	sendRPCRecord(t, conn, call)
+	reply := recvRPCRecord(t, conn)
+
+	r := newXDRReader(reply)
+	r.readUint32() // xid
+	r.readUint32() // msg_type
+	r.readUint32() // reply_stat
+	r.readUint32() // verifier flavor
+	r.readOpaque() // verifier body
+	acceptStat, _ := r.readUint32()
+	if acceptStat != acceptSuccess {
+		t.Fatalf("expected SUCCESS, got %d", acceptStat)
+	}
+
+	nfsStatus, _ := r.readUint32()
+	if nfsStatus != nfs3OK {
+		t.Fatalf("expected NFS3_OK, got %d", nfsStatus)
+	}
+
+	// Verify the file was truncated to 5 bytes
+	data, ok := handler.files[2]
+	if !ok {
+		t.Fatal("file was deleted")
+	}
+	if len(data) != 5 {
+		t.Errorf("expected file size 5, got %d", len(data))
+	}
+	expected := "hello"
+	if string(data) != expected {
+		t.Errorf("expected content %q, got %q", expected, string(data))
+	}
+}
+
+// TestNFSServer_SetattrTruncateLarger tests truncating a file to a larger size (extending with zeros).
+func TestNFSServer_SetattrTruncateLarger(t *testing.T) {
+	handler := newTruncationTestHandler()
+	// Pre-populate a file with content
+	handler.files[2] = []byte("hello") // 5 bytes
+
+	srv := NewNFSServer(handler, nil)
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- srv.Serve("127.0.0.1:0")
+	}()
+
+	addr := waitForAddr(srv, 2*time.Second)
+	if addr == nil {
+		t.Fatal("server did not start listening within timeout")
+	}
+	t.Cleanup(func() {
+		srv.Stop()
+		<-errCh
+	})
+
+	conn, err := net.DialTimeout("tcp", addr.String(), time.Second)
+	if err != nil {
+		t.Fatalf("failed to connect: %v", err)
+	}
+	defer conn.Close()
+
+	fileHandle := srv.handles.getOrCreateHandle(2)
+
+	// Build SETATTR payload to extend to size 10.
+	pw := newXDRWriter()
+	pw.writeOpaque(fileHandle)
+	// sattr3
+	pw.writeBool(false)  // set_mode
+	pw.writeBool(false)  // set_uid
+	pw.writeBool(false)  // set_gid
+	pw.writeBool(true)   // set_size = true
+	pw.writeUint64(10)   // new size = 10
+	pw.writeUint32(0)    // set_atime = DONT_CHANGE
+	pw.writeUint32(0)    // set_mtime = DONT_CHANGE
+	// sattrguard3
+	pw.writeBool(false)
+
+	call := buildRPCCall(1, nfsProg, nfsVersion, nfsProcSetattr, pw.Bytes())
+	sendRPCRecord(t, conn, call)
+	reply := recvRPCRecord(t, conn)
+
+	r := newXDRReader(reply)
+	r.readUint32() // xid
+	r.readUint32() // msg_type
+	r.readUint32() // reply_stat
+	r.readUint32() // verifier flavor
+	r.readOpaque() // verifier body
+	acceptStat, _ := r.readUint32()
+	if acceptStat != acceptSuccess {
+		t.Fatalf("expected SUCCESS, got %d", acceptStat)
+	}
+
+	nfsStatus, _ := r.readUint32()
+	if nfsStatus != nfs3OK {
+		t.Fatalf("expected NFS3_OK, got %d", nfsStatus)
+	}
+
+	// Verify the file was extended to 10 bytes
+	data, ok := handler.files[2]
+	if !ok {
+		t.Fatal("file was deleted")
+	}
+	if len(data) != 10 {
+		t.Errorf("expected file size 10, got %d", len(data))
+	}
+	// First 5 bytes should be "hello", rest should be zeros
+	if string(data[:5]) != "hello" {
+		t.Errorf("expected first 5 bytes to be 'hello', got %q", string(data[:5]))
+	}
+	for i := 5; i < 10; i++ {
+		if data[i] != 0 {
+			t.Errorf("expected byte %d to be 0, got %d", i, data[i])
+		}
+	}
+}
+
+// TestNFSServer_SetattrTruncateWithMode tests truncating a file while also changing mode.
+func TestNFSServer_SetattrTruncateWithMode(t *testing.T) {
+	handler := newTruncationTestHandler()
+	handler.files[2] = []byte("hello world") // 11 bytes
+
+	srv := NewNFSServer(handler, nil)
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- srv.Serve("127.0.0.1:0")
+	}()
+
+	addr := waitForAddr(srv, 2*time.Second)
+	if addr == nil {
+		t.Fatal("server did not start listening within timeout")
+	}
+	t.Cleanup(func() {
+		srv.Stop()
+		<-errCh
+	})
+
+	conn, err := net.DialTimeout("tcp", addr.String(), time.Second)
+	if err != nil {
+		t.Fatalf("failed to connect: %v", err)
+	}
+	defer conn.Close()
+
+	fileHandle := srv.handles.getOrCreateHandle(2)
+
+	// Build SETATTR payload to truncate to size 0 and change mode.
+	pw := newXDRWriter()
+	pw.writeOpaque(fileHandle)
+	// sattr3
+	pw.writeBool(true)   // set_mode = true
+	pw.writeUint32(0600) // new mode
+	pw.writeBool(false)  // set_uid
+	pw.writeBool(false)  // set_gid
+	pw.writeBool(true)   // set_size = true
+	pw.writeUint64(0)    // new size = 0
+	pw.writeUint32(0)    // set_atime = DONT_CHANGE
+	pw.writeUint32(0)    // set_mtime = DONT_CHANGE
+	// sattrguard3
+	pw.writeBool(false)
+
+	call := buildRPCCall(1, nfsProg, nfsVersion, nfsProcSetattr, pw.Bytes())
+	sendRPCRecord(t, conn, call)
+	reply := recvRPCRecord(t, conn)
+
+	r := newXDRReader(reply)
+	r.readUint32() // xid
+	r.readUint32() // msg_type
+	r.readUint32() // reply_stat
+	r.readUint32() // verifier flavor
+	r.readOpaque() // verifier body
+	acceptStat, _ := r.readUint32()
+	if acceptStat != acceptSuccess {
+		t.Fatalf("expected SUCCESS, got %d", acceptStat)
+	}
+
+	nfsStatus, _ := r.readUint32()
+	if nfsStatus != nfs3OK {
+		t.Fatalf("expected NFS3_OK, got %d", nfsStatus)
+	}
+
+	// Verify the file was truncated
+	data, ok := handler.files[2]
+	if !ok {
+		t.Fatal("file was deleted")
+	}
+	if len(data) != 0 {
+		t.Errorf("expected file size 0, got %d", len(data))
+	}
+}
+
+// TestNFSServer_SetattrTruncateDirectory tests that truncating a directory returns an error.
+func TestNFSServer_SetattrTruncateDirectory(t *testing.T) {
+	handler := newTruncationTestHandler()
+
+	srv := NewNFSServer(handler, nil)
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- srv.Serve("127.0.0.1:0")
+	}()
+
+	addr := waitForAddr(srv, 2*time.Second)
+	if addr == nil {
+		t.Fatal("server did not start listening within timeout")
+	}
+	t.Cleanup(func() {
+		srv.Stop()
+		<-errCh
+	})
+
+	conn, err := net.DialTimeout("tcp", addr.String(), time.Second)
+	if err != nil {
+		t.Fatalf("failed to connect: %v", err)
+	}
+	defer conn.Close()
+
+	// Use root handle (a directory)
+	rootHandle := srv.handles.getOrCreateHandle(1)
+
+	// Build SETATTR payload to attempt truncating a directory.
+	pw := newXDRWriter()
+	pw.writeOpaque(rootHandle)
+	// sattr3
+	pw.writeBool(false)  // set_mode
+	pw.writeBool(false)  // set_uid
+	pw.writeBool(false)  // set_gid
+	pw.writeBool(true)   // set_size = true
+	pw.writeUint64(0)    // new size = 0
+	pw.writeUint32(0)    // set_atime = DONT_CHANGE
+	pw.writeUint32(0)    // set_mtime = DONT_CHANGE
+	// sattrguard3
+	pw.writeBool(false)
+
+	call := buildRPCCall(1, nfsProg, nfsVersion, nfsProcSetattr, pw.Bytes())
+	sendRPCRecord(t, conn, call)
+	reply := recvRPCRecord(t, conn)
+
+	r := newXDRReader(reply)
+	r.readUint32() // xid
+	r.readUint32() // msg_type
+	r.readUint32() // reply_stat
+	r.readUint32() // verifier flavor
+	r.readOpaque() // verifier body
+	acceptStat, _ := r.readUint32()
+	if acceptStat != acceptSuccess {
+		t.Fatalf("expected SUCCESS, got %d", acceptStat)
+	}
+
+	nfsStatus, _ := r.readUint32()
+	if nfsStatus != nfs3ErrInval {
+		t.Fatalf("expected NFS3_ERR_INVAL for directory truncate, got %d", nfsStatus)
 	}
 }

--- a/internal/filer/nfs_v3.go
+++ b/internal/filer/nfs_v3.go
@@ -467,13 +467,39 @@ func (n *nfsV3Handler) handleSetattr(ctx context.Context, payload []byte) ([]byt
 	before := *meta
 
 	// Read sattr3.
-	mode, uid, gid, _, sErr := readSattr3(r)
+	mode, uid, gid, size, sErr := readSattr3(r)
 	if sErr != nil {
 		return nfsErrorReplyWcc(nfs3ErrInval), nil
 	}
 
-	// Apply attributes. We only support mode, uid, gid for now.
-	// Size truncation is not supported in this implementation.
+	// Handle size truncation first, before applying other attributes.
+	// This must be done for regular files only.
+	if size != nil {
+		if meta.Type != TypeFile {
+			w := newXDRWriter()
+			w.writeUint32(nfs3ErrInval)
+			n.writeWcc(w, &before, meta)
+			return w.Bytes(), nil
+		}
+		if err := n.fs.Truncate(ctx, ino, int64(*size)); err != nil {
+			logging.L.Warn("nfs: truncate failed",
+				zap.Uint64("ino", ino),
+				zap.Int64("size", int64(*size)),
+				zap.Error(err),
+			)
+			w := newXDRWriter()
+			w.writeUint32(nfs3ErrIO)
+			n.writeWcc(w, &before, meta)
+			return w.Bytes(), nil
+		}
+		// Refresh metadata after truncate to get updated size.
+		meta, err = n.fs.Stat(ctx, ino)
+		if err != nil {
+			return nfsErrorReplyWcc(nfs3ErrIO), nil
+		}
+	}
+
+	// Apply other attributes. We support mode, uid, gid.
 	if mode != nil {
 		meta.Mode = *mode
 	}


### PR DESCRIPTION
## Summary

- Implemented file size truncation in the NFS v3 SETATTR procedure
- Added `Truncate` method to the `NFSHandler` interface and `FileSystem` type
- SETATTR now properly handles the `size` attribute to truncate files

## Implementation Details

### Changes to `internal/filer/nfs.go`
- Added `Truncate(ctx context.Context, ino uint64, size int64) error` to the `NFSHandler` interface

### Changes to `internal/filer/fs.go`
- Implemented `Truncate` method on `FileSystem` that:
  - Validates the size parameter (must be non-negative)
  - Reads existing file data if chunks exist
  - Creates a new buffer with the specified size
  - Copies existing data up to the new size
  - Writes new chunks and updates inode metadata

### Changes to `internal/filer/nfs_v3.go`
- Modified `handleSetattr` to process the size attribute
- Returns `NFS3_ERR_INVAL` when attempting to truncate directories
- Calls `Truncate` method when size is set
- Refreshes metadata after truncate to get updated size

## Test Coverage

Added comprehensive tests in `internal/filer/nfs_test.go` and `internal/filer/fs_test.go`:
- `TestNFSServer_SetattrTruncateToZero` - Truncating file to size 0
- `TestNFSServer_SetattrTruncateSmaller` - Shrinking file to smaller size
- `TestNFSServer_SetattrTruncateLarger` - Extending file with zeros
- `TestNFSServer_SetattrTruncateWithMode` - Truncating while changing mode
- `TestNFSServer_SetattrTruncateDirectory` - Verifies error when truncating directory
- `TestTruncate` - Unit test for FileSystem.Truncate method

All tests pass.

Resolves #69