### PR TITLE
[Feature #98] Add Kubernetes event recorder to policy engine

### DIFF
--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -214,7 +214,7 @@ func main() {
 	}
 
 	// Create event recorder for policy engine.
-	eventRecorder := mgr.GetEventRecorderFor("policy-engine")
+	eventRecorder := mgr.GetEventRecorder("policy-engine")
 
 	// Register controllers.
 	if err := (&controller.StoragePoolReconciler{

--- a/internal/policy/reconciler.go
+++ b/internal/policy/reconciler.go
@@ -8,7 +8,7 @@ import (
 
 	"go.uber.org/zap"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/client-go/tools/record"
+	"k8s.io/client-go/tools/events"
 
 	"github.com/piwi3910/novastor/api/v1alpha1"
 	"github.com/piwi3910/novastor/internal/logging"
@@ -21,7 +21,7 @@ type Reconciler struct {
 	poolLookup      PoolLookup
 	chunkReplicator ChunkReplicator
 	shardReplicator ShardReplicator
-	eventRecorder   record.EventRecorder
+	eventRecorder   events.EventRecorder
 
 	mu               sync.Mutex
 	maxConcurrent    int
@@ -79,7 +79,7 @@ func (r *Reconciler) SetShardReplicator(replicator ShardReplicator) {
 }
 
 // SetEventRecorder sets the Kubernetes event recorder for emitting events.
-func (r *Reconciler) SetEventRecorder(recorder record.EventRecorder) {
+func (r *Reconciler) SetEventRecorder(recorder events.EventRecorder) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	r.eventRecorder = recorder
@@ -465,7 +465,7 @@ func (r *Reconciler) emitHealingTaskEvent(task RepairTask) {
 	message := fmt.Sprintf("Healing task created for chunk %s (volume: %s, mode: %s, status: %s)",
 		task.ChunkID, task.VolumeID, task.ProtectionMode, task.Status)
 
-	recorder.Event(pool, corev1.EventTypeNormal, "HealingTaskCreated", message)
+	recorder.Eventf(pool, nil, corev1.EventTypeNormal, "HealingTaskCreated", "CreateHealingTask", message)
 }
 
 // emitRepairCompletedEvent emits an event when a repair completes successfully.
@@ -484,7 +484,7 @@ func (r *Reconciler) emitRepairCompletedEvent(task RepairTask) {
 
 	message := fmt.Sprintf("Repair completed for chunk %s (volume: %s)", task.ChunkID, task.VolumeID)
 
-	recorder.Event(pool, corev1.EventTypeNormal, "HealingCompleted", message)
+	recorder.Eventf(pool, nil, corev1.EventTypeNormal, "HealingCompleted", "CompleteRepair", message)
 }
 
 // emitRepairFailedEvent emits an event when a repair fails.
@@ -503,5 +503,5 @@ func (r *Reconciler) emitRepairFailedEvent(task RepairTask, err error) {
 
 	message := fmt.Sprintf("Repair failed for chunk %s (volume: %s): %v", task.ChunkID, task.VolumeID, err)
 
-	recorder.Event(pool, corev1.EventTypeWarning, "HealingFailed", message)
+	recorder.Eventf(pool, nil, corev1.EventTypeWarning, "HealingFailed", "FailRepair", message)
 }

--- a/internal/policy/runnable.go
+++ b/internal/policy/runnable.go
@@ -10,7 +10,7 @@ import (
 	"go.uber.org/zap"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/client-go/tools/record"
+	"k8s.io/client-go/tools/events"
 )
 
 // PolicyEngineRunnable wraps the policy engine and reconciler as a controller-runtime Runnable.
@@ -20,7 +20,7 @@ type PolicyEngineRunnable struct {
 	metrics       *MetricsReporter
 	scanInterval  time.Duration
 	repairEnabled bool
-	eventRecorder record.EventRecorder
+	eventRecorder events.EventRecorder
 }
 
 // NewPolicyEngineRunnable creates a new PolicyEngineRunnable.
@@ -30,7 +30,7 @@ func NewPolicyEngineRunnable(
 	nodeChecker NodeAvailabilityChecker,
 	chunkReplicator ChunkReplicator,
 	shardReplicator ShardReplicator,
-	eventRecorder record.EventRecorder,
+	eventRecorder events.EventRecorder,
 	scanInterval time.Duration,
 	repairEnabled bool,
 ) *PolicyEngineRunnable {
@@ -208,5 +208,5 @@ func (r *PolicyEngineRunnable) emitComplianceEvent(poolName string, report *Pool
 	message := fmt.Sprintf("Pool compliance check failed: %d under-replicated, %d unavailable, %d corrupted chunks",
 		report.UnderReplicatedChunks, report.UnavailableChunks, report.CorruptedChunks)
 
-	r.eventRecorder.Event(pool, corev1.EventTypeWarning, "ComplianceCheckFailed", message)
+	r.eventRecorder.Eventf(pool, nil, corev1.EventTypeWarning, "ComplianceCheckFailed", "CheckCompliance", message)
 }


### PR DESCRIPTION
Adds Kubernetes event recorder to policy engine for improved observability of self-healing operations.

- Create event recorder in controller startup
- Pass recorder to policy engine runnable
- Emit events for compliance failures, healing operations, node status

Event types emitted:
- ComplianceCheckFailed (Warning) - Pool fails compliance check
- HealingTaskCreated (Normal) - Repair task enqueued
- HealingCompleted (Normal) - Repair succeeds
- HealingFailed (Warning) - Repair fails

Resolves #98