### PR TITLE
[Test] Document multi-device test bug findings

### DIFF
--- a/internal/chunk/blockstore_test.go
+++ b/internal/chunk/blockstore_test.go
@@ -387,8 +387,11 @@ func TestBlockStoreMultiDevice(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping multi-device test in short mode")
 	}
-	// TODO: Investigate checksum mismatch with multiple devices
-	t.Skip("multi-device test needs investigation")
+	// TODO: Fix checksum mismatch with multiple devices
+	// The chunk allocation across devices causes data corruption.
+	// Root cause: BlockStore's device selection logic doesn't properly
+	// account for the chunk header when computing device offsets.
+	t.Skip("multi-device test has known bug - checksum mismatch")
 
 	tmpDir := t.TempDir()
 
@@ -466,8 +469,10 @@ func TestBlockStoreRecovery(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping recovery test in short mode")
 	}
-	// TODO: Investigate recovery after multi-device write
-	t.Skip("recovery test needs investigation")
+	// TODO: Fix recovery after multi-device write
+	// Same root cause as TestBlockStoreMultiDevice - the metadata
+	// recovery doesn't properly handle the corrupted checksum data.
+	t.Skip("recovery test has known bug - depends on multi-device fix")
 
 	tmpDir := t.TempDir()
 	devicePath := filepath.Join(tmpDir, "device.img")


### PR DESCRIPTION
Updates the skip comments for \`TestBlockStoreMultiDevice\` and \`TestBlockStoreRecovery\` with detailed explanation of the underlying bug.

## Bug Analysis

The tests fail with **checksum mismatch** errors when using multiple devices. Investigation reveals:

**Root cause**: \`BlockStore\`'s device selection logic doesn't properly account for the chunk header when computing device offsets in multi-device scenarios.

### Test Output (with skip removed)
\`\`\`
checksum mismatch for chunk bb9f8df6...: stored=3156861858 computed=3315510689
checksum mismatch for chunk 5d2bafc2...: stored=2012861755 computed=3492049336
...
\`\`\`

### Affected Code
- \`internal/chunk/blockstore.go\` - Device allocation and offset calculation
- Multi-device round-robin selection doesn't handle chunk header size correctly

## Impact

- Multi-device stripe behavior is untested
- Recovery scenarios after multi-device writes are untested  
- Potential data integrity issues in production with multi-device pools

## Next Steps

This PR documents the bug. A follow-up issue should be created to:
1. Fix the device offset calculation in multi-device allocation
2. Re-enable these tests after the fix is verified

Related to #91