### PR TITLE
[Fix] Improve NFS v3 ACCESS permission checking and cleanup

### DIFF
--- a/cmd/filer/main.go
+++ b/cmd/filer/main.go
@@ -160,8 +160,7 @@ func main() {
 
 // runNFSServer starts and manages the NFS server.
 func runNFSServer(ctx context.Context, fs *filer.FileSystem, listenAddr string, stop chan os.Signal) {
-	locker := filer.NewLockManager()
-	nfsSrv := filer.NewNFSServer(fs, locker)
+	nfsSrv := filer.NewNFSServer(fs)
 
 	go func() {
 		if err := nfsSrv.Serve(ctx, listenAddr); err != nil {

--- a/internal/filer/nfs.go
+++ b/internal/filer/nfs.go
@@ -39,7 +39,6 @@ type NFSHandler interface {
 // user-space NFS servers.
 type NFSServer struct {
 	handler    NFSHandler
-	locker     *LockManager
 	handles    *handleManager
 	dispatcher *rpcDispatcher
 	mu         sync.Mutex
@@ -48,21 +47,22 @@ type NFSServer struct {
 	exportPath string
 }
 
-// NewNFSServer creates a new NFSServer with the given handler and lock manager.
+// NewNFSServer creates a new NFSServer with the given handler.
 // The server supports NFS v3 and MOUNT v3 protocols over a single TCP listener.
-func NewNFSServer(handler NFSHandler, locker *LockManager) *NFSServer {
+// Note: NFS v3 does not include lock procedures (locking is handled by the
+// separate NLM protocol), so no LockManager is needed here.
+func NewNFSServer(handler NFSHandler) *NFSServer {
 	handles := newHandleManager()
 	dispatcher := newRPCDispatcher()
 
 	mountH := newMountHandler(handles, "/")
-	nfsH := newNFSV3Handler(handler, handles, locker)
+	nfsH := newNFSV3Handler(handler, handles)
 
 	dispatcher.register(mountH)
 	dispatcher.register(nfsH)
 
 	return &NFSServer{
 		handler:    handler,
-		locker:     locker,
 		handles:    handles,
 		dispatcher: dispatcher,
 		exportPath: "/",

--- a/internal/filer/nfs_test.go
+++ b/internal/filer/nfs_test.go
@@ -190,7 +190,7 @@ func readFull(r net.Conn, buf []byte) (int, error) {
 
 func startTestServer(t *testing.T) (*NFSServer, net.Addr) {
 	t.Helper()
-	srv := NewNFSServer(&stubNFSHandler{}, nil)
+	srv := NewNFSServer(&stubNFSHandler{})
 	errCh := make(chan error, 1)
 	go func() {
 		errCh <- srv.Serve(context.Background(), "127.0.0.1:0")
@@ -210,7 +210,7 @@ func startTestServer(t *testing.T) (*NFSServer, net.Addr) {
 }
 
 func TestNFSServer_StartStop(t *testing.T) {
-	srv := NewNFSServer(&stubNFSHandler{}, nil)
+	srv := NewNFSServer(&stubNFSHandler{})
 
 	errCh := make(chan error, 1)
 	go func() {
@@ -243,7 +243,7 @@ func TestNFSServer_StartStop(t *testing.T) {
 }
 
 func TestNFSServer_AcceptConnection(t *testing.T) {
-	srv := NewNFSServer(&stubNFSHandler{}, nil)
+	srv := NewNFSServer(&stubNFSHandler{})
 
 	errCh := make(chan error, 1)
 	go func() {
@@ -2022,7 +2022,7 @@ func TestNFSServer_SetattrTruncateToZero(t *testing.T) {
 	// Pre-populate a file with content
 	handler.files[2] = []byte("hello world, this is some data")
 
-	srv := NewNFSServer(handler, nil)
+	srv := NewNFSServer(handler)
 	errCh := make(chan error, 1)
 	go func() {
 		errCh <- srv.Serve(context.Background(), "127.0.0.1:0")
@@ -2095,7 +2095,7 @@ func TestNFSServer_SetattrTruncateSmaller(t *testing.T) {
 	// Pre-populate a file with content
 	handler.files[2] = []byte("hello world, this is some data") // 31 bytes
 
-	srv := NewNFSServer(handler, nil)
+	srv := NewNFSServer(handler)
 	errCh := make(chan error, 1)
 	go func() {
 		errCh <- srv.Serve(context.Background(), "127.0.0.1:0")
@@ -2172,7 +2172,7 @@ func TestNFSServer_SetattrTruncateLarger(t *testing.T) {
 	// Pre-populate a file with content
 	handler.files[2] = []byte("hello") // 5 bytes
 
-	srv := NewNFSServer(handler, nil)
+	srv := NewNFSServer(handler)
 	errCh := make(chan error, 1)
 	go func() {
 		errCh <- srv.Serve(context.Background(), "127.0.0.1:0")
@@ -2253,7 +2253,7 @@ func TestNFSServer_SetattrTruncateWithMode(t *testing.T) {
 	handler := newTruncationTestHandler()
 	handler.files[2] = []byte("hello world") // 11 bytes
 
-	srv := NewNFSServer(handler, nil)
+	srv := NewNFSServer(handler)
 	errCh := make(chan error, 1)
 	go func() {
 		errCh <- srv.Serve(context.Background(), "127.0.0.1:0")
@@ -2325,7 +2325,7 @@ func TestNFSServer_SetattrTruncateWithMode(t *testing.T) {
 func TestNFSServer_SetattrTruncateDirectory(t *testing.T) {
 	handler := newTruncationTestHandler()
 
-	srv := NewNFSServer(handler, nil)
+	srv := NewNFSServer(handler)
 	errCh := make(chan error, 1)
 	go func() {
 		errCh <- srv.Serve(context.Background(), "127.0.0.1:0")

--- a/internal/filer/nfs_v3.go
+++ b/internal/filer/nfs_v3.go
@@ -100,15 +100,13 @@ const (
 type nfsV3Handler struct {
 	fs            NFSHandler
 	handles       *handleManager
-	locker        *LockManager
 	writeVerifier [8]byte // stable across server lifetime, changes on restart
 }
 
-func newNFSV3Handler(fs NFSHandler, handles *handleManager, locker *LockManager) *nfsV3Handler {
+func newNFSV3Handler(fs NFSHandler, handles *handleManager) *nfsV3Handler {
 	h := &nfsV3Handler{
 		fs:      fs,
 		handles: handles,
-		locker:  locker,
 	}
 	// Generate write verifier from current time (changes on each server restart).
 	now := time.Now().UnixNano()
@@ -594,11 +592,51 @@ func (n *nfsV3Handler) handleAccess(ctx context.Context, payload []byte) ([]byte
 		return nfsErrorReply(nfs3ErrIO, err), nil
 	}
 
-	// Grant all requested access (NovaStor does not enforce POSIX permissions at the NFS layer).
+	// Check file mode bits against the requested access mask.
+	// We use the owner permission bits (bits 8-6) since NFS v3 AUTH_UNIX
+	// credentials are not validated at this layer.
+	mode := meta.Mode & 0o777
+	isDir := meta.Type == TypeDir
+
+	var granted uint32
+	if accessRequested&access3Read != 0 {
+		if mode&0o400 != 0 {
+			granted |= access3Read
+		}
+	}
+	if accessRequested&access3Lookup != 0 {
+		// LOOKUP only applies to directories.
+		if isDir && mode&0o100 != 0 {
+			granted |= access3Lookup
+		}
+	}
+	if accessRequested&access3Modify != 0 {
+		if mode&0o200 != 0 {
+			granted |= access3Modify
+		}
+	}
+	if accessRequested&access3Extend != 0 {
+		if mode&0o200 != 0 {
+			granted |= access3Extend
+		}
+	}
+	if accessRequested&access3Delete != 0 {
+		// DELETE requires write permission on the parent directory, but we
+		// only have the target inode here. Grant if the target is writable.
+		if mode&0o200 != 0 {
+			granted |= access3Delete
+		}
+	}
+	if accessRequested&access3Execute != 0 {
+		if mode&0o100 != 0 {
+			granted |= access3Execute
+		}
+	}
+
 	w := newXDRWriter()
 	w.writeUint32(nfs3OK)
 	n.writePostOpAttr(w, meta)
-	w.writeUint32(accessRequested)
+	w.writeUint32(granted)
 	return w.Bytes(), nil
 }
 
@@ -696,6 +734,9 @@ func (n *nfsV3Handler) handleWrite(ctx context.Context, payload []byte) ([]byte,
 	if err != nil {
 		return nfsErrorReplyWcc(nfs3ErrInval, err), nil
 	}
+	// The stable parameter is intentionally ignored. NovaStor always writes
+	// synchronously to the chunk storage engine, so all writes are effectively
+	// FILE_SYNC regardless of the client's requested stability level.
 	_ = stable
 
 	data, err := r.readOpaque()
@@ -1482,6 +1523,10 @@ func (n *nfsV3Handler) handlePathConf(ctx context.Context, payload []byte) ([]by
 	return w.Bytes(), nil
 }
 
+// handleCommit is intentionally a no-op. Since all WRITE operations use
+// FILE_SYNC (data is committed synchronously to chunk storage), there is
+// never any unstable data to flush. The COMMIT procedure still returns
+// success with the write verifier so clients can detect server restarts.
 func (n *nfsV3Handler) handleCommit(ctx context.Context, payload []byte) ([]byte, error) {
 	r := newXDRReader(payload)
 	ino, _, err := n.resolveHandle(r)
@@ -1489,7 +1534,7 @@ func (n *nfsV3Handler) handleCommit(ctx context.Context, payload []byte) ([]byte
 		return nfsErrorReplyWcc(nfs3ErrStale, err), nil
 	}
 
-	// offset and count
+	// offset and count are unused since there is no unstable data to flush.
 	_, _ = r.readUint64()
 	_, _ = r.readUint32()
 

--- a/test/e2e/file_storage_test.go
+++ b/test/e2e/file_storage_test.go
@@ -669,9 +669,8 @@ func TestFileStorage_NFSOperations(t *testing.T) {
 	// Create the filesystem layer (initializes root inode).
 	fs := filer.NewFileSystem(metaAdapter, chunkAdapter)
 
-	// Create the NFS server with a lock manager.
-	locker := filer.NewLockManager()
-	nfsServer := filer.NewNFSServer(fs, locker)
+	// Create the NFS server.
+	nfsServer := filer.NewNFSServer(fs)
 
 	// Start the NFS server on a random port.
 	nfsLis, err := (&net.ListenConfig{}).Listen(context.Background(), "tcp", "127.0.0.1:0")


### PR DESCRIPTION
## Summary
- Implement proper permission checking in NFS v3 ACCESS procedure based on file mode bits instead of granting all access unconditionally
- Remove unused `LockManager` from `NFSServer` (NFS v3 has no lock procedures; that's NLM)
- Document intentional FILE_SYNC behavior in WRITE and COMMIT handlers

## Test plan
- [ ] `go build ./cmd/filer/` compiles
- [ ] `go test -race ./internal/filer/...` passes
- [ ] ACCESS now returns only permissions that match file mode bits

Resolves #97