### PR TITLE
SPDK active-active read scaling with latency-aware steering

### DIFF
--- a/dataplane/src/bdev/replica.rs
+++ b/dataplane/src/bdev/replica.rs
@@ -1,11 +1,16 @@
 //! Replica bdev: fans out writes to N replicas with majority quorum,
-//! distributes reads via round-robin or local-first policy.
+//! distributes reads via round-robin, local-first, or latency-aware policy.
 
 use crate::config::{ReadPolicy, ReplicaBdevConfig, ReplicaTarget};
 use crate::error::{DataPlaneError, Result};
 use log::{debug, info, warn};
-use std::sync::atomic::{AtomicU32, AtomicU8, Ordering};
+use std::sync::atomic::{AtomicU32, AtomicU64, AtomicU8, Ordering};
 use std::sync::{Arc, RwLock};
+use std::time::Instant;
+
+/// EMA smoothing factor as fixed-point (alpha = 0.1, stored as 10 out of 100).
+const EMA_ALPHA_NUM: u64 = 10;
+const EMA_ALPHA_DEN: u64 = 100;
 
 #[repr(u8)]
 #[derive(Debug, Clone, Copy, PartialEq)]
@@ -31,6 +36,10 @@ pub struct ReplicaStats {
     pub writes_completed: AtomicU32,
     pub read_errors: AtomicU32,
     pub write_errors: AtomicU32,
+    pub read_bytes: AtomicU64,
+    pub write_bytes: AtomicU64,
+    /// Exponential moving average of read latency in microseconds.
+    pub avg_read_latency_us: AtomicU64,
 }
 
 pub struct Replica {
@@ -69,6 +78,18 @@ impl Replica {
         info!("replica {} marked healthy", self.target.address);
     }
 
+    /// Records a read latency sample and updates the EMA.
+    pub fn record_read_latency(&self, latency_us: u64) {
+        let old = self.stats.avg_read_latency_us.load(Ordering::Relaxed);
+        let new_avg = if old == 0 {
+            latency_us
+        } else {
+            // EMA: new = alpha * sample + (1 - alpha) * old
+            (EMA_ALPHA_NUM * latency_us + (EMA_ALPHA_DEN - EMA_ALPHA_NUM) * old) / EMA_ALPHA_DEN
+        };
+        self.stats.avg_read_latency_us.store(new_avg, Ordering::Relaxed);
+    }
+
     /// Returns a snapshot of this replica's status information.
     pub fn status_info(&self) -> ReplicaStatusInfo {
         ReplicaStatusInfo {
@@ -79,6 +100,8 @@ impl Replica {
             writes_completed: self.stats.writes_completed.load(Ordering::Relaxed),
             read_errors: self.stats.read_errors.load(Ordering::Relaxed),
             write_errors: self.stats.write_errors.load(Ordering::Relaxed),
+            read_bytes: self.stats.read_bytes.load(Ordering::Relaxed),
+            avg_read_latency_us: self.stats.avg_read_latency_us.load(Ordering::Relaxed),
         }
     }
 }
@@ -90,6 +113,10 @@ pub struct ReplicaBdev {
     pub read_policy: ReadPolicy,
     read_index: AtomicU32,
     pub bdev_name: String,
+    created_at: Instant,
+    /// Tracks cumulative write quorum latency in microseconds for averaging.
+    write_quorum_latency_sum_us: AtomicU64,
+    write_quorum_count: AtomicU64,
 }
 
 impl ReplicaBdev {
@@ -112,6 +139,9 @@ impl ReplicaBdev {
             read_policy: config.read_policy,
             read_index: AtomicU32::new(0),
             bdev_name,
+            created_at: Instant::now(),
+            write_quorum_latency_sum_us: AtomicU64::new(0),
+            write_quorum_count: AtomicU64::new(0),
         }
     }
 
@@ -137,10 +167,69 @@ impl ReplicaBdev {
                 let idx = self.read_index.fetch_add(1, Ordering::Relaxed);
                 Ok(healthy[idx as usize % healthy.len()].clone())
             }
+            ReadPolicy::LatencyAware => {
+                self.select_latency_aware(&healthy)
+            }
         }
     }
 
-    pub fn submit_write(&self, _offset: u64, _data: &[u8]) -> Result<()> {
+    /// Selects a replica using weighted round-robin based on inverse latency.
+    /// Replicas with lower latency get proportionally more reads.
+    /// Falls back to simple round-robin if no latency data is available.
+    fn select_latency_aware(&self, healthy: &[Arc<Replica>]) -> Result<Arc<Replica>> {
+        // Collect latencies; 0 means no data yet
+        let latencies: Vec<u64> = healthy
+            .iter()
+            .map(|r| r.stats.avg_read_latency_us.load(Ordering::Relaxed))
+            .collect();
+
+        // If all latencies are 0 (no data), fall back to round-robin
+        if latencies.iter().all(|&l| l == 0) {
+            let idx = self.read_index.fetch_add(1, Ordering::Relaxed);
+            return Ok(healthy[idx as usize % healthy.len()].clone());
+        }
+
+        // Compute weights as inverse of latency (use 1 for unknown latencies).
+        // To avoid division, use max_latency / latency_i as the weight.
+        let max_latency = *latencies.iter().max().unwrap_or(&1);
+        let max_latency = max_latency.max(1); // avoid division by zero
+
+        let weights: Vec<u64> = latencies
+            .iter()
+            .map(|&l| {
+                if l == 0 {
+                    // No data yet — give it equal weight to max
+                    1
+                } else {
+                    // Higher weight for lower latency
+                    max_latency / l.max(1)
+                }
+            })
+            .collect();
+
+        let total_weight: u64 = weights.iter().sum();
+        if total_weight == 0 {
+            let idx = self.read_index.fetch_add(1, Ordering::Relaxed);
+            return Ok(healthy[idx as usize % healthy.len()].clone());
+        }
+
+        // Weighted round-robin: use read_index mod total_weight to pick
+        let idx = self.read_index.fetch_add(1, Ordering::Relaxed) as u64;
+        let slot = idx % total_weight;
+
+        let mut cumulative = 0u64;
+        for (i, &w) in weights.iter().enumerate() {
+            cumulative += w;
+            if slot < cumulative {
+                return Ok(healthy[i].clone());
+            }
+        }
+
+        // Fallback (shouldn't happen)
+        Ok(healthy[healthy.len() - 1].clone())
+    }
+
+    pub fn submit_write(&self, _offset: u64, data: &[u8]) -> Result<()> {
         let healthy = self.healthy_replicas();
         let healthy_count = healthy.len() as u32;
         if healthy_count < self.write_quorum {
@@ -150,21 +239,39 @@ impl ReplicaBdev {
             )));
         }
 
+        let start = Instant::now();
+        let data_len = data.len() as u64;
+
         // Production SPDK: spdk_bdev_write() to each replica bdev descriptor,
         // track completions, ACK on quorum.
         debug!("write submitted to {} replicas (quorum={})", healthy_count, self.write_quorum);
         for replica in &healthy {
             replica.stats.writes_completed.fetch_add(1, Ordering::Relaxed);
+            replica.stats.write_bytes.fetch_add(data_len, Ordering::Relaxed);
         }
+
+        let elapsed_us = start.elapsed().as_micros() as u64;
+        self.write_quorum_latency_sum_us.fetch_add(elapsed_us, Ordering::Relaxed);
+        self.write_quorum_count.fetch_add(1, Ordering::Relaxed);
+
         Ok(())
     }
 
     pub fn submit_read(&self, _offset: u64, length: u64) -> Result<Vec<u8>> {
+        let start = Instant::now();
         let replica = self.select_read_replica()?;
         // Production SPDK: spdk_bdev_read() on selected replica bdev descriptor.
         debug!("read submitted to replica {}", replica.target.address);
         replica.stats.reads_completed.fetch_add(1, Ordering::Relaxed);
-        Ok(vec![0u8; length as usize])
+        replica.stats.read_bytes.fetch_add(length, Ordering::Relaxed);
+
+        let result = vec![0u8; length as usize];
+
+        // Record read latency for this replica
+        let elapsed_us = start.elapsed().as_micros() as u64;
+        replica.record_read_latency(elapsed_us);
+
+        Ok(result)
     }
 
     pub fn replica_status(&self) -> Vec<ReplicaStatusInfo> {
@@ -214,11 +321,60 @@ impl ReplicaBdev {
         let replicas = self.replicas.read().unwrap();
         let replica_infos: Vec<ReplicaStatusInfo> = replicas.iter().map(|r| r.status_info()).collect();
         let healthy_count = replicas.iter().filter(|r| r.is_healthy()).count() as u32;
+
+        let total_read_iops: u64 = replica_infos.iter().map(|r| r.reads_completed as u64).sum();
+        let total_write_iops: u64 = replica_infos.iter().map(|r| r.writes_completed as u64).sum();
+
+        let wq_count = self.write_quorum_count.load(Ordering::Relaxed);
+        let write_quorum_latency_us = if wq_count > 0 {
+            self.write_quorum_latency_sum_us.load(Ordering::Relaxed) / wq_count
+        } else {
+            0
+        };
+
         ReplicaBdevStatus {
             volume_id: self.volume_id.clone(),
             replicas: replica_infos,
             write_quorum: self.write_quorum,
             healthy_count,
+            total_read_iops,
+            total_write_iops,
+            write_quorum_latency_us,
+        }
+    }
+
+    /// Returns I/O statistics for this replica bdev.
+    pub fn io_stats(&self) -> IoStats {
+        let replicas = self.replicas.read().unwrap();
+        let replica_stats: Vec<ReplicaIoStats> = replicas.iter().map(|r| {
+            ReplicaIoStats {
+                address: r.target.address.clone(),
+                port: r.target.port,
+                reads_completed: r.stats.reads_completed.load(Ordering::Relaxed) as u64,
+                read_bytes: r.stats.read_bytes.load(Ordering::Relaxed),
+                avg_read_latency_us: r.stats.avg_read_latency_us.load(Ordering::Relaxed),
+            }
+        }).collect();
+
+        let total_read_iops: u64 = replica_stats.iter().map(|r| r.reads_completed).sum();
+        let total_write_iops: u64 = replicas
+            .iter()
+            .map(|r| r.stats.writes_completed.load(Ordering::Relaxed) as u64)
+            .sum();
+
+        let wq_count = self.write_quorum_count.load(Ordering::Relaxed);
+        let write_quorum_latency_us = if wq_count > 0 {
+            self.write_quorum_latency_sum_us.load(Ordering::Relaxed) / wq_count
+        } else {
+            0
+        };
+
+        IoStats {
+            volume_id: self.volume_id.clone(),
+            replicas: replica_stats,
+            total_read_iops,
+            total_write_iops,
+            write_quorum_latency_us,
         }
     }
 }
@@ -232,6 +388,8 @@ pub struct ReplicaStatusInfo {
     pub writes_completed: u32,
     pub read_errors: u32,
     pub write_errors: u32,
+    pub read_bytes: u64,
+    pub avg_read_latency_us: u64,
 }
 
 /// Full status report for a ReplicaBdev.
@@ -241,6 +399,29 @@ pub struct ReplicaBdevStatus {
     pub replicas: Vec<ReplicaStatusInfo>,
     pub write_quorum: u32,
     pub healthy_count: u32,
+    pub total_read_iops: u64,
+    pub total_write_iops: u64,
+    pub write_quorum_latency_us: u64,
+}
+
+/// Per-replica I/O statistics for the novastor_io_stats RPC.
+#[derive(Debug, Clone)]
+pub struct ReplicaIoStats {
+    pub address: String,
+    pub port: u16,
+    pub reads_completed: u64,
+    pub read_bytes: u64,
+    pub avg_read_latency_us: u64,
+}
+
+/// Aggregated I/O statistics for a volume.
+#[derive(Debug, Clone)]
+pub struct IoStats {
+    pub volume_id: String,
+    pub replicas: Vec<ReplicaIoStats>,
+    pub total_read_iops: u64,
+    pub total_write_iops: u64,
+    pub write_quorum_latency_us: u64,
 }
 
 #[cfg(test)]
@@ -268,6 +449,16 @@ mod tests {
             replicas: targets,
             write_quorum: 1,
             read_policy: ReadPolicy::RoundRobin,
+        };
+        ReplicaBdev::new(config)
+    }
+
+    fn make_latency_bdev(targets: Vec<ReplicaTarget>) -> ReplicaBdev {
+        let config = ReplicaBdevConfig {
+            volume_id: "test-vol".into(),
+            replicas: targets,
+            write_quorum: 1,
+            read_policy: ReadPolicy::LatencyAware,
         };
         ReplicaBdev::new(config)
     }
@@ -363,5 +554,139 @@ mod tests {
         assert_eq!(info.state, ReplicaState::Healthy);
         assert_eq!(info.reads_completed, 5);
         assert_eq!(info.writes_completed, 3);
+    }
+
+    #[test]
+    fn test_ema_latency_tracking() {
+        let target = ReplicaTarget {
+            address: "10.0.0.1".into(),
+            port: 4420,
+            nqn: "nqn-1".into(),
+        };
+        let replica = Replica::new(target, "test-bdev".into());
+
+        // First sample — becomes the initial value
+        replica.record_read_latency(1000);
+        assert_eq!(replica.stats.avg_read_latency_us.load(Ordering::Relaxed), 1000);
+
+        // Second sample — EMA: 0.1 * 2000 + 0.9 * 1000 = 200 + 900 = 1100
+        replica.record_read_latency(2000);
+        assert_eq!(replica.stats.avg_read_latency_us.load(Ordering::Relaxed), 1100);
+
+        // Third sample — EMA: 0.1 * 500 + 0.9 * 1100 = 50 + 990 = 1040
+        replica.record_read_latency(500);
+        assert_eq!(replica.stats.avg_read_latency_us.load(Ordering::Relaxed), 1040);
+    }
+
+    #[test]
+    fn test_latency_aware_no_data_falls_back_to_round_robin() {
+        let bdev = make_latency_bdev(test_targets());
+
+        // No latency data yet — should distribute evenly
+        let mut counts = [0u32; 2];
+        for _ in 0..100 {
+            let r = bdev.select_read_replica().unwrap();
+            if r.target.address == "10.0.0.1" {
+                counts[0] += 1;
+            } else {
+                counts[1] += 1;
+            }
+        }
+        // Should be roughly 50/50
+        assert_eq!(counts[0], 50);
+        assert_eq!(counts[1], 50);
+    }
+
+    #[test]
+    fn test_latency_aware_prefers_lower_latency() {
+        let bdev = make_latency_bdev(test_targets());
+
+        // Set latencies: replica 0 = 100us, replica 1 = 400us
+        // Weight: replica 0 = 400/100 = 4, replica 1 = 400/400 = 1
+        // Total weight = 5, so replica 0 gets 4/5 = 80%, replica 1 gets 1/5 = 20%
+        {
+            let replicas = bdev.replicas.read().unwrap();
+            replicas[0].stats.avg_read_latency_us.store(100, Ordering::Relaxed);
+            replicas[1].stats.avg_read_latency_us.store(400, Ordering::Relaxed);
+        }
+
+        let mut counts = [0u32; 2];
+        for _ in 0..100 {
+            let r = bdev.select_read_replica().unwrap();
+            if r.target.address == "10.0.0.1" {
+                counts[0] += 1;
+            } else {
+                counts[1] += 1;
+            }
+        }
+
+        // With weights 4:1, replica 0 should get ~80 reads
+        assert_eq!(counts[0], 80);
+        assert_eq!(counts[1], 20);
+    }
+
+    #[test]
+    fn test_latency_aware_equal_latency_distributes_evenly() {
+        let bdev = make_latency_bdev(test_targets());
+
+        // Set equal latencies
+        {
+            let replicas = bdev.replicas.read().unwrap();
+            replicas[0].stats.avg_read_latency_us.store(200, Ordering::Relaxed);
+            replicas[1].stats.avg_read_latency_us.store(200, Ordering::Relaxed);
+        }
+
+        let mut counts = [0u32; 2];
+        for _ in 0..100 {
+            let r = bdev.select_read_replica().unwrap();
+            if r.target.address == "10.0.0.1" {
+                counts[0] += 1;
+            } else {
+                counts[1] += 1;
+            }
+        }
+
+        // Equal latency → equal weight → 50/50
+        assert_eq!(counts[0], 50);
+        assert_eq!(counts[1], 50);
+    }
+
+    #[test]
+    fn test_io_stats() {
+        let bdev = make_bdev(test_targets());
+
+        // Simulate some I/O
+        bdev.submit_write(0, &[0u8; 4096]).unwrap();
+        bdev.submit_read(0, 4096).unwrap();
+        bdev.submit_read(0, 4096).unwrap();
+
+        let stats = bdev.io_stats();
+        assert_eq!(stats.volume_id, "test-vol");
+        assert_eq!(stats.replicas.len(), 2);
+        assert_eq!(stats.total_write_iops, 2); // both replicas got the write
+        assert_eq!(stats.total_read_iops, 2); // round-robin distributed reads
+    }
+
+    #[test]
+    fn test_read_bytes_tracking() {
+        let bdev = make_bdev(test_targets());
+
+        bdev.submit_read(0, 4096).unwrap();
+        bdev.submit_read(0, 8192).unwrap();
+
+        let stats = bdev.io_stats();
+        let total_read_bytes: u64 = stats.replicas.iter().map(|r| r.read_bytes).sum();
+        assert_eq!(total_read_bytes, 4096 + 8192);
+    }
+
+    #[test]
+    fn test_write_bytes_tracking() {
+        let bdev = make_bdev(test_targets());
+
+        bdev.submit_write(0, &[0u8; 4096]).unwrap();
+
+        let status = bdev.full_status();
+        // Both replicas get the write, so total_write_iops = 2
+        assert_eq!(status.total_write_iops, 2);
     }
 }

--- a/dataplane/src/config.rs
+++ b/dataplane/src/config.rs
@@ -92,6 +92,7 @@ pub enum ReadPolicy {
     #[default]
     RoundRobin,
     LocalFirst { local_address: String },
+    LatencyAware,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/dataplane/src/jsonrpc/methods.rs
+++ b/dataplane/src/jsonrpc/methods.rs
@@ -50,6 +50,7 @@ pub fn register_all(router: &mut Router) {
     router.register("replica_bdev_status", wrap(handle_replica_status));
     router.register("replica_bdev_add_replica", wrap(handle_replica_add));
     router.register("replica_bdev_remove_replica", wrap(handle_replica_remove));
+    router.register("novastor_io_stats", wrap(handle_io_stats));
     router.register("get_version", wrap(get_version));
 }
 
@@ -226,6 +227,7 @@ fn replica_bdev_create(p: ReplicaBdevCreateParams) -> Result<serde_json::Value, 
                 .unwrap_or_default();
             ReadPolicy::LocalFirst { local_address: local_addr }
         }
+        Some("latency_aware") => ReadPolicy::LatencyAware,
         _ => ReadPolicy::RoundRobin,
     };
 
@@ -340,6 +342,8 @@ fn handle_replica_status(p: ReplicaStatusParams) -> Result<serde_json::Value, Da
             "writes_completed": r.writes_completed,
             "read_errors": r.read_errors,
             "write_errors": r.write_errors,
+            "read_bytes": r.read_bytes,
+            "avg_read_latency_us": r.avg_read_latency_us,
         })
     }).collect();
 
@@ -348,6 +352,45 @@ fn handle_replica_status(p: ReplicaStatusParams) -> Result<serde_json::Value, Da
         "replicas": replica_infos,
         "write_quorum": status.write_quorum,
         "healthy_count": status.healthy_count,
+        "total_read_iops": status.total_read_iops,
+        "total_write_iops": status.total_write_iops,
+        "write_quorum_latency_us": status.write_quorum_latency_us,
+    }))
+}
+
+// ---------------------------------------------------------------------------
+// I/O statistics
+// ---------------------------------------------------------------------------
+
+#[derive(Deserialize)]
+struct IoStatsParams {
+    volume_id: String,
+}
+
+fn handle_io_stats(p: IoStatsParams) -> Result<serde_json::Value, DataPlaneError> {
+    let registry = replica_bdevs().lock().unwrap();
+    let bdev = registry.get(&p.volume_id).ok_or_else(|| {
+        DataPlaneError::ReplicaError(format!("replica bdev {} not found", p.volume_id))
+    })?.clone();
+    drop(registry);
+
+    let stats = bdev.io_stats();
+    let replica_stats: Vec<serde_json::Value> = stats.replicas.iter().map(|r| {
+        serde_json::json!({
+            "addr": r.address,
+            "port": r.port,
+            "reads_completed": r.reads_completed,
+            "read_bytes": r.read_bytes,
+            "avg_read_latency_us": r.avg_read_latency_us,
+        })
+    }).collect();
+
+    Ok(serde_json::json!({
+        "volume_id": stats.volume_id,
+        "replicas": replica_stats,
+        "total_read_iops": stats.total_read_iops,
+        "total_write_iops": stats.total_write_iops,
+        "write_quorum_latency_us": stats.write_quorum_latency_us,
     }))
 }
 

--- a/docs/architecture/spdk-dataplane.md
+++ b/docs/architecture/spdk-dataplane.md
@@ -69,7 +69,7 @@ sequenceDiagram
     DP-->>Agent: replica bdev ready
 
     Note over DP: Write path: fan-out to all replicas, ACK on majority
-    Note over DP: Read path: round-robin across healthy replicas
+    Note over DP: Read path: distributed across healthy replicas (configurable policy)
 ```
 
 ## Components
@@ -85,6 +85,38 @@ The data-plane binary runs as a DaemonSet sidecar alongside the Go agent on each
 | **NVMe-oF Manager** | Exposes bdevs as NVMe-oF/TCP targets, connects to remote targets |
 | **Replica Bdev** | Custom bdev that replicates writes with quorum ACK and distributes reads |
 | **JSON-RPC Server** | Unix domain socket server for Go control plane communication |
+
+### Read Scaling Policies
+
+The replica bdev supports three read distribution policies, selected at creation time via the `read_policy` parameter:
+
+| Policy | Description | Best For |
+|---|---|---|
+| `round_robin` | Distributes reads evenly across all healthy replicas | General workloads, maximum aggregate throughput |
+| `local_first` | Prefers the local replica for reads, falls back to round-robin for remote | Latency-sensitive workloads with local replica |
+| `latency_aware` | Weighted round-robin based on per-replica EMA latency | Heterogeneous networks, asymmetric load |
+
+**Latency-aware steering** tracks each replica's average read latency using an exponential moving average (EMA, alpha=0.1). Replicas with lower latency receive proportionally more reads via weighted round-robin. This automatically adapts to load imbalances and network asymmetry.
+
+The agent auto-selects `local_first` when the consuming node has a local replica, and `latency_aware` otherwise.
+
+### I/O Statistics
+
+The `novastor_io_stats` RPC returns per-replica read distribution metrics:
+
+```json
+{
+  "volume_id": "vol-abc",
+  "replicas": [
+    { "addr": "10.42.1.5", "reads_completed": 1500, "read_bytes": 6291456, "avg_read_latency_us": 120 },
+    { "addr": "10.42.2.3", "reads_completed": 1480, "read_bytes": 6209536, "avg_read_latency_us": 135 },
+    { "addr": "10.42.3.7", "reads_completed": 1520, "read_bytes": 6373376, "avg_read_latency_us": 118 }
+  ],
+  "total_read_iops": 4500,
+  "total_write_iops": 1200,
+  "write_quorum_latency_us": 250
+}
+```
 
 ### JSON-RPC Interface
 
@@ -105,7 +137,8 @@ The Go agent communicates with the Rust data-plane over a Unix domain socket at 
 | `nvmf_disconnect_initiator` | Disconnect from a remote target |
 | `nvmf_export_local` | Create loopback NVMe-oF for local consumption |
 | `replica_bdev_create` | Create a replica bdev across targets |
-| `replica_bdev_status` | Query replica health |
+| `replica_bdev_status` | Query replica health and I/O stats |
+| `novastor_io_stats` | Per-replica I/O distribution metrics |
 | `nvmf_set_ana_state` | Set ANA state for an NVMe-oF target |
 | `nvmf_get_ana_state` | Get ANA state for an NVMe-oF target |
 | `replica_bdev_add_replica` | Add replica to running bdev |

--- a/docs/operations/monitoring.md
+++ b/docs/operations/monitoring.md
@@ -325,3 +325,30 @@ groups:
           summary: "NovaStor agent is down"
           description: "Agent on {{ $labels.instance }} has been unreachable for over 2 minutes."
 ```
+
+## Data Plane I/O Statistics
+
+The SPDK data plane exposes per-volume I/O statistics via the `novastor_io_stats` JSON-RPC method. These metrics are useful for monitoring read distribution across replicas and identifying performance bottlenecks.
+
+### Key Metrics
+
+| Metric | Description |
+|---|---|
+| `reads_completed` (per replica) | Total read I/Os completed by each replica |
+| `read_bytes` (per replica) | Total bytes read from each replica |
+| `avg_read_latency_us` (per replica) | Exponential moving average of read latency in microseconds |
+| `total_read_iops` | Aggregate read I/O count across all replicas |
+| `total_write_iops` | Aggregate write I/O count across all replicas |
+| `write_quorum_latency_us` | Average write quorum completion latency in microseconds |
+
+### Verifying Read Distribution
+
+Use the `novastor_io_stats` RPC to verify reads are evenly distributed:
+
+```bash
+# Via kubectl exec to the dataplane pod
+kubectl exec -n novastor-system <dataplane-pod> -- \
+  /usr/local/bin/novastor-dataplane --rpc-call novastor_io_stats '{"volume_id":"<vol>"}'
+```
+
+For a 3-replica volume with `round_robin` or `latency_aware` policy, `reads_completed` should be roughly balanced across replicas. For `local_first`, the local replica will have significantly higher `reads_completed`.

--- a/internal/agent/spdk_replica.go
+++ b/internal/agent/spdk_replica.go
@@ -14,8 +14,16 @@ import (
 // SetupReplicaBdev creates a replica bdev in the SPDK data-plane for a volume.
 // It looks up the placement map to find all replica nodes, connects to their
 // NVMe-oF targets, and creates a composite bdev that fans out writes with
-// majority-quorum ACK and distributes reads via round-robin.
-func SetupReplicaBdev(ctx context.Context, spdkClient *spdk.Client, metaClient *metadata.GRPCClient, volumeID, localNodeID string, replicaNodes []string) (string, error) {
+// majority-quorum ACK and distributes reads based on the selected policy.
+//
+// Read policy selection:
+//   - "local_first": if the local node is one of the replicas, prefer it for reads
+//   - "latency_aware": steer reads toward the lowest-latency replica
+//   - "round_robin": distribute reads evenly (default fallback)
+//
+// When readPolicy is empty, automatically selects "local_first" if the local
+// node is a replica, otherwise "latency_aware".
+func SetupReplicaBdev(ctx context.Context, spdkClient *spdk.Client, metaClient *metadata.GRPCClient, volumeID, localNodeID string, replicaNodes []string, readPolicy string) (string, error) {
 	if len(replicaNodes) == 0 {
 		return "", fmt.Errorf("no replica nodes for volume %s", volumeID)
 	}
@@ -24,8 +32,12 @@ func SetupReplicaBdev(ctx context.Context, spdkClient *spdk.Client, metaClient *
 	nqn := nqnPrefix + volumeID
 	targets := make([]spdk.ReplicaTarget, 0, len(replicaNodes))
 
+	hasLocal := false
 	for _, nodeAddr := range replicaNodes {
 		isLocal := nodeAddr == localNodeID
+		if isLocal {
+			hasLocal = true
+		}
 		target := spdk.ReplicaTarget{
 			Addr:    nodeAddr,
 			Port:    4420,
@@ -35,14 +47,24 @@ func SetupReplicaBdev(ctx context.Context, spdkClient *spdk.Client, metaClient *
 		targets = append(targets, target)
 	}
 
+	// Auto-select read policy if not explicitly set
+	if readPolicy == "" {
+		if hasLocal {
+			readPolicy = "local_first"
+		} else {
+			readPolicy = "latency_aware"
+		}
+	}
+
 	bdevName := fmt.Sprintf("replica-%s", volumeID)
-	if err := spdkClient.CreateReplicaBdev(bdevName, targets, "round-robin"); err != nil {
+	if err := spdkClient.CreateReplicaBdev(bdevName, targets, readPolicy); err != nil {
 		return "", fmt.Errorf("creating replica bdev for volume %s: %w", volumeID, err)
 	}
 
 	logging.L.Info("replica bdev created",
 		zap.String("volumeID", volumeID),
 		zap.String("bdevName", bdevName),
+		zap.String("readPolicy", readPolicy),
 		zap.Int("replicaCount", len(targets)),
 	)
 

--- a/internal/spdk/client.go
+++ b/internal/spdk/client.go
@@ -245,21 +245,44 @@ type ReplicaTarget struct {
 
 // ReplicaBdevStatus represents the status of a replica bdev.
 type ReplicaBdevStatus struct {
-	VolumeID     string              `json:"volume_id"`
-	Replicas     []ReplicaStatusInfo `json:"replicas"`
-	WriteQuorum  uint32              `json:"write_quorum"`
-	HealthyCount uint32              `json:"healthy_count"`
+	VolumeID             string              `json:"volume_id"`
+	Replicas             []ReplicaStatusInfo `json:"replicas"`
+	WriteQuorum          uint32              `json:"write_quorum"`
+	HealthyCount         uint32              `json:"healthy_count"`
+	TotalReadIOPS        uint64              `json:"total_read_iops"`
+	TotalWriteIOPS       uint64              `json:"total_write_iops"`
+	WriteQuorumLatencyUs uint64              `json:"write_quorum_latency_us"`
 }
 
 // ReplicaStatusInfo describes the state and I/O statistics of a single replica.
 type ReplicaStatusInfo struct {
-	Address         string `json:"address"`
-	Port            uint16 `json:"port"`
-	State           string `json:"state"`
-	ReadsCompleted  uint64 `json:"reads_completed"`
-	WritesCompleted uint64 `json:"writes_completed"`
-	ReadErrors      uint64 `json:"read_errors"`
-	WriteErrors     uint64 `json:"write_errors"`
+	Address          string `json:"address"`
+	Port             uint16 `json:"port"`
+	State            string `json:"state"`
+	ReadsCompleted   uint64 `json:"reads_completed"`
+	WritesCompleted  uint64 `json:"writes_completed"`
+	ReadErrors       uint64 `json:"read_errors"`
+	WriteErrors      uint64 `json:"write_errors"`
+	ReadBytes        uint64 `json:"read_bytes"`
+	AvgReadLatencyUs uint64 `json:"avg_read_latency_us"`
+}
+
+// IOStats represents per-volume I/O statistics from the data-plane.
+type IOStats struct {
+	VolumeID             string           `json:"volume_id"`
+	Replicas             []ReplicaIOStats `json:"replicas"`
+	TotalReadIOPS        uint64           `json:"total_read_iops"`
+	TotalWriteIOPS       uint64           `json:"total_write_iops"`
+	WriteQuorumLatencyUs uint64           `json:"write_quorum_latency_us"`
+}
+
+// ReplicaIOStats describes per-replica I/O distribution metrics.
+type ReplicaIOStats struct {
+	Addr             string `json:"addr"`
+	Port             uint16 `json:"port"`
+	ReadsCompleted   uint64 `json:"reads_completed"`
+	ReadBytes        uint64 `json:"read_bytes"`
+	AvgReadLatencyUs uint64 `json:"avg_read_latency_us"`
 }
 
 // CreateReplicaBdev creates a composite bdev that replicates writes across targets.
@@ -325,6 +348,15 @@ func (c *Client) RemoveReplica(bdevName, targetAddr string) error {
 func (c *Client) GetReplicaBdevStatus(bdevName string) (*ReplicaBdevStatus, error) {
 	var result ReplicaBdevStatus
 	if err := c.call("replica_bdev_status", map[string]interface{}{"volume_id": bdevName}, &result); err != nil {
+		return nil, err
+	}
+	return &result, nil
+}
+
+// GetIOStats returns per-volume I/O statistics including per-replica read distribution.
+func (c *Client) GetIOStats(volumeID string) (*IOStats, error) {
+	var result IOStats
+	if err := c.call("novastor_io_stats", map[string]interface{}{"volume_id": volumeID}, &result); err != nil {
 		return nil, err
 	}
 	return &result, nil


### PR DESCRIPTION
## Summary

- Add **latency-aware read policy** to the SPDK replica bdev: per-replica EMA latency tracking with weighted round-robin distribution favoring lower-latency replicas
- Add **`novastor_io_stats` JSON-RPC method** exposing per-replica I/O distribution metrics (reads, bytes, latency, write quorum latency)
- **Auto-select read policy**: `local_first` when local node is a replica, `latency_aware` otherwise
- Enhanced `replica_bdev_status` with `total_read_iops`, `total_write_iops`, `write_quorum_latency_us`, per-replica `read_bytes` and `avg_read_latency_us`

## Changes

### Rust Data Plane (`dataplane/`)
- `config.rs`: Add `LatencyAware` variant to `ReadPolicy` enum
- `bdev/replica.rs`: EMA latency tracking, weighted round-robin selection, read/write bytes tracking, `io_stats()` method, 7 new unit tests
- `jsonrpc/methods.rs`: Handle `"latency_aware"` policy in `replica_bdev_create`, add `novastor_io_stats` RPC, enhanced `replica_bdev_status` response

### Go Agent/Client (`internal/`)
- `spdk/client.go`: Updated `ReplicaStatusInfo`/`ReplicaBdevStatus` structs, new `IOStats`/`ReplicaIOStats` types, `GetIOStats()` method
- `agent/spdk_replica.go`: Auto-select read policy based on local node presence

### Documentation (`docs/`)
- `architecture/spdk-dataplane.md`: Read scaling policies section, I/O statistics example, `novastor_io_stats` in method table
- `operations/monitoring.md`: Data plane I/O statistics section

## Test plan

- [x] 14 Rust unit tests pass (including 7 new tests for latency-aware policy)
- [x] Full Go test suite passes with `-race`
- [x] `golangci-lint` clean (0 issues)
- [x] Containers built and deployed to k3s cluster (8 dataplane pods running)
- [ ] CI passes

Resolves #148