### PR TITLE
[Fix] Start JSON-RPC server from SPDK startup callback

### DIFF
--- a/dataplane/src/jsonrpc/mod.rs
+++ b/dataplane/src/jsonrpc/mod.rs
@@ -1,4 +1,2 @@
 pub mod methods;
 pub mod server;
-
-pub use server::start_server;

--- a/dataplane/src/spdk/env.rs
+++ b/dataplane/src/spdk/env.rs
@@ -1,7 +1,7 @@
 //! SPDK environment initialization and reactor management.
 
 use crate::config::DataPlaneConfig;
-use crate::error::{DataPlaneError, Result};
+use crate::error::Result;
 use log::info;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
@@ -12,6 +12,13 @@ mod ffi {
     include!(concat!(env!("OUT_DIR"), "/spdk_bindings.rs"));
 }
 
+/// Data passed to the SPDK startup callback via the arg pointer.
+#[cfg(feature = "spdk-sys")]
+struct SpdkStartupData {
+    rpc_socket: String,
+    listen_port: u16,
+}
+
 pub fn init_spdk_env(config: &DataPlaneConfig) -> Result<()> {
     info!(
         "SPDK env init: reactor_mask={}, mem={}MB",
@@ -20,6 +27,8 @@ pub fn init_spdk_env(config: &DataPlaneConfig) -> Result<()> {
 
     #[cfg(feature = "spdk-sys")]
     {
+        use crate::error::DataPlaneError;
+
         unsafe {
             let rust_size = std::mem::size_of::<ffi::spdk_app_opts>();
             info!("sizeof(spdk_app_opts) in Rust = {} bytes (C expects 253)", rust_size);
@@ -38,7 +47,17 @@ pub fn init_spdk_env(config: &DataPlaneConfig) -> Result<()> {
             opts.hugedir = hugedir.as_ptr();
             opts.rpc_addr = std::ptr::null();
 
-            let rc = ffi::spdk_app_start(&mut opts, Some(spdk_startup_cb), std::ptr::null_mut());
+            // Package config for the startup callback.  The callback runs
+            // inside spdk_app_start *before* the reactor loop blocks, so the
+            // JSON-RPC server is guaranteed to be listening before any agent
+            // tries to connect.
+            let startup_data = Box::new(SpdkStartupData {
+                rpc_socket: config.rpc_socket.clone(),
+                listen_port: config.listen_port,
+            });
+            let arg = Box::into_raw(startup_data) as *mut std::os::raw::c_void;
+
+            let rc = ffi::spdk_app_start(&mut opts, Some(spdk_startup_cb), arg);
             if rc != 0 {
                 return Err(DataPlaneError::SpdkInit(format!(
                     "spdk_app_start failed with rc={}", rc
@@ -56,8 +75,37 @@ pub fn init_spdk_env(config: &DataPlaneConfig) -> Result<()> {
 }
 
 #[cfg(feature = "spdk-sys")]
-unsafe extern "C" fn spdk_startup_cb(_arg: *mut std::os::raw::c_void) {
+unsafe extern "C" fn spdk_startup_cb(arg: *mut std::os::raw::c_void) {
+    use log::error;
+
     info!("SPDK startup callback: subsystems initialized");
+
+    // Recover the startup data passed through the arg pointer.
+    let data = Box::from_raw(arg as *mut SpdkStartupData);
+
+    // Initialise managers and register RPC methods.
+    let bdev_mgr = crate::spdk::bdev_manager::BdevManager::new();
+    let nvmf_mgr = crate::spdk::nvmf_manager::NvmfManager::new(data.listen_port);
+    crate::jsonrpc::methods::init_managers(bdev_mgr, nvmf_mgr);
+
+    let mut router = crate::jsonrpc::server::Router::new();
+    crate::jsonrpc::methods::register_all(&mut router);
+    let router = Arc::new(router);
+
+    info!("starting JSON-RPC server on {}", data.rpc_socket);
+    match crate::jsonrpc::server::start_server(&data.rpc_socket, router) {
+        Ok(_handle) => {
+            // The JoinHandle is dropped here, which detaches the listener
+            // thread.  It will run for the lifetime of the process, which
+            // is controlled by the SPDK reactor loop.
+            info!("JSON-RPC server started successfully");
+        }
+        Err(e) => {
+            error!("failed to start JSON-RPC server: {}", e);
+            // Cannot operate without the RPC server — stop SPDK.
+            ffi::spdk_app_stop(-1);
+        }
+    }
 }
 
 pub fn run_reactor_loop() -> Result<()> {

--- a/dataplane/src/spdk/mod.rs
+++ b/dataplane/src/spdk/mod.rs
@@ -4,34 +4,48 @@ pub mod bdev_manager;
 pub mod env;
 pub mod nvmf_manager;
 
-use std::sync::Arc;
-
 use crate::config::DataPlaneConfig;
 use crate::error::Result;
-use crate::jsonrpc;
-use crate::jsonrpc::server::Router;
-use log::info;
 
 /// Run the SPDK data plane application.
+///
+/// In SPDK mode (`spdk-sys` feature), `init_spdk_env` calls `spdk_app_start`
+/// which invokes the startup callback and then blocks in the reactor loop.
+/// The callback initialises managers and starts the JSON-RPC server before
+/// the reactor takes over.
+///
+/// In stub mode (no `spdk-sys`), `init_spdk_env` returns immediately and we
+/// initialise managers, start the JSON-RPC server, and enter a simple
+/// Ctrl-C–driven wait loop here.
 pub fn run(config: DataPlaneConfig) -> Result<()> {
-    let rpc_socket = config.rpc_socket.clone();
-
+    // In SPDK mode this blocks until spdk_app_stop is called (e.g. SIGINT).
+    // The JSON-RPC server is started from inside the startup callback.
     env::init_spdk_env(&config)?;
 
-    // Initialise managers and register RPC methods.
-    let bdev_mgr = bdev_manager::BdevManager::new();
-    let nvmf_mgr = nvmf_manager::NvmfManager::new(config.listen_port);
-    jsonrpc::methods::init_managers(bdev_mgr, nvmf_mgr);
+    // Stub mode: init_spdk_env returned immediately — set up JSON-RPC and
+    // enter the stub reactor loop.
+    #[cfg(not(feature = "spdk-sys"))]
+    {
+        use std::sync::Arc;
 
-    let mut router = Router::new();
-    jsonrpc::methods::register_all(&mut router);
-    let router = Arc::new(router);
+        use crate::jsonrpc;
+        use crate::jsonrpc::server::Router;
+        use log::info;
 
-    info!("starting JSON-RPC server on {}", rpc_socket);
-    let _rpc_handle = jsonrpc::server::start_server(&rpc_socket, router)?;
+        let bdev_mgr = bdev_manager::BdevManager::new();
+        let nvmf_mgr = nvmf_manager::NvmfManager::new(config.listen_port);
+        jsonrpc::methods::init_managers(bdev_mgr, nvmf_mgr);
 
-    info!("entering SPDK reactor loop");
-    env::run_reactor_loop()?;
+        let mut router = Router::new();
+        jsonrpc::methods::register_all(&mut router);
+        let router = Arc::new(router);
+
+        info!("starting JSON-RPC server on {}", config.rpc_socket);
+        let _rpc_handle = jsonrpc::server::start_server(&config.rpc_socket, router)?;
+
+        info!("entering SPDK reactor loop");
+        env::run_reactor_loop()?;
+    }
 
     env::shutdown_spdk_env();
     Ok(())


### PR DESCRIPTION
## Summary

- `spdk_app_start()` blocks in the reactor loop, which prevented the JSON-RPC server from ever starting in full SPDK mode. The setup code in `mod.rs` ran *after* `init_spdk_env()` returned — but it never returns while SPDK is active.
- Moved JSON-RPC server initialization (manager creation, router setup, socket listener) into `spdk_startup_cb`, which runs before the reactor loop takes over. Config is passed through the callback arg pointer via `Box<SpdkStartupData>`.
- Stub mode (no `spdk-sys` feature) is unchanged — setup runs sequentially in `mod.rs`.

## Files Changed

| File | Change |
|------|--------|
| `dataplane/src/spdk/env.rs` | Add `SpdkStartupData`, pass config through arg pointer, start JSON-RPC in callback |
| `dataplane/src/spdk/mod.rs` | Gate post-init code with `#[cfg(not(feature = "spdk-sys"))]` |
| `dataplane/src/jsonrpc/mod.rs` | Remove unused `pub use server::start_server` re-export |

## Test plan

- [x] `cargo build` — compiles in stub mode
- [x] `cargo test` — all 14 Rust tests pass
- [x] `go test -race ./...` — all Go tests pass
- [x] `make lint` — 0 issues
- [x] Built dataplane container with full SPDK support and deployed to k3s cluster
- [x] Verified `get_version` JSON-RPC call returns valid response through `/var/tmp/novastor-spdk.sock` on live dataplane pods
- [x] Verified error handling (method not found, missing volume) returns proper JSON-RPC 2.0 errors