### PR TITLE
Fix GHCR image paths for Docker push

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -145,6 +145,6 @@ jobs:
           file: ${{ matrix.component.dockerfile }}
           platforms: linux/amd64,linux/arm64
           push: true
-          tags: ghcr.io/piwi3910/novastor-${{ matrix.component.name }}:nightly
+          tags: ghcr.io/piwi3910/novastor/novastor-${{ matrix.component.name }}:nightly
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -107,7 +107,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ghcr.io/piwi3910/novastor-${{ matrix.component.name }}
+          images: ghcr.io/piwi3910/novastor/novastor-${{ matrix.component.name }}
           tags: |
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}

--- a/deploy/manifests/scheduler.yaml
+++ b/deploy/manifests/scheduler.yaml
@@ -97,7 +97,7 @@ spec:
       serviceAccountName: novastor-scheduler
       containers:
         - name: scheduler
-          image: ghcr.io/piwi3910/novastor-scheduler:latest
+          image: ghcr.io/piwi3910/novastor/novastor-scheduler:latest
           imagePullPolicy: IfNotPresent
           args:
             - --log-level=info
@@ -157,7 +157,7 @@ spec:
       serviceAccountName: novastor-scheduler
       containers:
         - name: scheduler
-          image: ghcr.io/piwi3910/novastor-scheduler:latest
+          image: ghcr.io/piwi3910/novastor/novastor-scheduler:latest
           imagePullPolicy: IfNotPresent
           args:
             - --log-level=info

--- a/docs/development/contributing.md
+++ b/docs/development/contributing.md
@@ -49,7 +49,7 @@ go build -o bin/novastor-controller ./cmd/controller/
 make docker-build
 
 # Build a specific image
-docker build -t ghcr.io/piwi3910/novastor-agent:dev -f build/Dockerfile.agent .
+docker build -t ghcr.io/piwi3910/novastor/novastor-agent:dev -f build/Dockerfile.agent .
 ```
 
 ## Running Tests

--- a/docs/index.md
+++ b/docs/index.md
@@ -89,6 +89,6 @@ graph TB
 ## Project Links
 
 - **Source Code**: [github.com/piwi3910/novastor](https://github.com/piwi3910/novastor)
-- **Container Images**: `ghcr.io/piwi3910/novastor-*`
+- **Container Images**: `ghcr.io/piwi3910/novastor/novastor-*`
 - **Module**: `github.com/piwi3910/novastor`
 - **License**: See repository


### PR DESCRIPTION
## Summary
- Fix Docker image paths in nightly and release workflows from `ghcr.io/piwi3910/novastor-<component>` to `ghcr.io/piwi3910/novastor/novastor-<component>`
- The flat path returns 403 Forbidden because GITHUB_TOKEN is scoped to the `novastor` repository namespace
- The Helm chart already uses the correct pattern (`registry: ghcr.io/piwi3910/novastor` + `repository: novastor-<component>`)
- Also updated docs and scheduler manifest references for consistency

## Files Changed
- `.github/workflows/nightly.yml` — Fix nightly Docker push tag
- `.github/workflows/release.yml` — Fix release Docker metadata images
- `docs/index.md` — Update container images reference
- `docs/development/contributing.md` — Update example docker build command
- `deploy/manifests/scheduler.yaml` — Update scheduler image references (2 occurrences)

## Test plan
- [ ] Verify nightly workflow Docker push succeeds (no more 403)
- [ ] Verify release workflow metadata-action generates correct tags
- [ ] Verify Helm chart image references match the new paths